### PR TITLE
Faster rebuild by sharing build results

### DIFF
--- a/src/Verify.hs
+++ b/src/Verify.hs
@@ -83,8 +83,6 @@ verifyPackageSet ps = do
 
   for_ (toList ps) $ \(name, PackageSpec{..}) -> do
     let dirFor = fromMaybe (error "verifyPackageSet: no directory") . (`M.lookup` paths)
-        pkgDir = dirFor name
     echo ("Building package " <> name)
-    pushd pkgDir $ do
-      let srcGlobs = "src/**/*.purs" : map (("../../../" <>) . (<> "/src/**/*.purs") . toTextUnsafe . dirFor) dependencies
-      procs "psc" srcGlobs empty
+    let srcGlobs = map ((<> "/src/**/*.purs") . toTextUnsafe . dirFor) (name : dependencies)
+    procs "psc" srcGlobs empty


### PR DESCRIPTION
I'm not sure if this is safe until https://github.com/purescript/purescript/issues/1921 is fixed, but it does speed up the builds a lot.