### PR TITLE
Add 'spec-quickcheck'

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1207,6 +1207,16 @@
     "repo": "https://github.com/owickstrom/purescript-spec.git",
     "version": "v1.0.0"
   },
+  "spec-quickcheck": {
+    "dependencies": [
+      "aff",
+      "random",
+      "quickcheck",
+      "spec"
+    ],
+    "repo": "https://github.com/owickstrom/purescript-spec-quickcheck.git",
+    "version": "v1.0.0"
+  },
   "st": {
     "dependencies": [
       "eff"


### PR DESCRIPTION
It would be great to have [`purescript-spec-quickcheck`](https://github.com/owickstrom/purescript-spec-quickcheck) ([Pursuit](https://pursuit.purescript.org/packages/purescript-spec-quickcheck)) available.

I've tried this branch out locally and it seems to work.