### PR TITLE
Restoring Halogen-Echarts.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -738,6 +738,14 @@
     "repo": "git://github.com/slamdata/purescript-halogen-css.git",
     "version": "v7.0.0"
   },
+  "halogen-echarts": {
+    "dependencies": [
+      "halogen-css",
+      "echarts"
+    ],
+    "repo": "https://github.com/slamdata/purescript-halogen-echarts.git",
+    "version": "v12.0.0"
+  },
   "halogen-vdom": {
     "dependencies": [
       "prelude",


### PR DESCRIPTION
Not sure why, but it got removed in the recent 0.11.7 release. Assuming that was an oversight, here's the fix.