### PR TITLE
Update `halogen-select` to most recent version

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -852,10 +852,11 @@
       "dom",
       "halogen",
       "aff",
-      "transformers"
+      "transformers",
+      "day"
     ],
     "repo": "https://github.com/citizennet/purescript-halogen-select.git",
-    "version": "v0.1.12"
+    "version": "v0.2.0"
   },
   "halogen-vdom": {
     "dependencies": [


### PR DESCRIPTION
The latest version of [`purescript-halogen-select`](https://github.com/citizennet/purescript-halogen-select) is a major update with some significant changes. This is definitely the version that ought to be included in psc-package. This PR updates the dependencies and version for the library.