### PR TITLE
Add `crypt-nacl` and `encoding`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -292,6 +292,20 @@
     "repo": "https://github.com/purescript-contrib/purescript-coroutines.git",
     "version": "v4.0.0"
   },
+  "crypt-nacl": {
+    "dependencies": [
+      "arraybuffer-types",
+      "eff",
+      "either",
+      "encoding",
+      "maybe",
+      "nullable",
+      "prelude",
+      "unsafe-coerce"
+    ],
+    "repo": "git://github.com/throughnothing/purescript-crypt-nacl.git",
+    "version": "v0.3.0"
+  },
   "crypto": {
     "dependencies": [
       "node-buffer",
@@ -468,6 +482,17 @@
     ],
     "repo": "https://github.com/cdepillabout/purescript-email-validate.git",
     "version": "v2.0.0"
+  },
+  "encoding": {
+    "dependencies": [
+      "arraybuffer-types",
+      "either",
+      "exceptions",
+      "functions",
+      "prelude"
+    ],
+    "repo": "git://github.com/menelaos/purescript-encoding.git",
+    "version": "v0.0.4"
   },
   "enums": {
     "dependencies": [


### PR DESCRIPTION
This adds `crypt-nacl` which is a purescript wrapper around the Javascript port of Daniel Bernstein's original [TweetNacl](https://tweetnacl.cr.yp.to/) cryptographic library.

It also adds an upstream dependency `purescript-encoding` which this library needs. 