### PR TITLE
Add behaviors, bigints, formatters, remotedata, email-validate, and read

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -148,12 +148,36 @@
     "repo": "https://github.com/slamdata/purescript-avar.git",
     "version": "v3.0.0"
   },
+  "behaviors": {
+    "dependencies": [
+      "prelude",
+      "effect",
+      "ordered-collections",
+      "filterable",
+      "nullable",
+      "event",
+      "web-html",
+      "web-events",
+      "web-uievents"
+    ],
+    "repo": "https://github.com/paf31/purescript-behaviors.git",
+    "version": "v7.0.0"
+  },
   "bifunctors": {
     "dependencies": [
       "newtype",
       "prelude"
     ],
     "repo": "https://github.com/purescript/purescript-bifunctors.git",
+    "version": "v4.0.0"
+  },
+  "bigints": {
+    "dependencies": [
+      "maybe",
+      "integers",
+      "strings",
+    ],
+    "repo": "https://github.com/sharkdp/purescript-bigints.git",
     "version": "v4.0.0"
   },
   "canvas": {
@@ -317,6 +341,15 @@
     "repo": "https://github.com/purescript/purescript-either.git",
     "version": "v4.0.0"
   },
+  "email-validate": {
+    "dependencies": [
+      "string-parsers",
+      "aff",
+      "transformers"
+    ],
+    "repo": "https://github.com/cdepillabout/purescript-email-validate.git",
+    "version": "v3.0.0"
+  },
   "enums": {
     "dependencies": [
       "control",
@@ -463,6 +496,19 @@
     "repo": "https://github.com/purescript-contrib/purescript-form-urlencoded.git",
     "version": "v4.0.0"
   },
+  "formatters": {
+    "dependencies": [
+      "fixed-points",
+      "datetime",
+      "generics-rep",
+      "transformers",
+      "lists",
+      "prelude",
+      "parsing"
+    ],
+    "repo": "https://github.com/slamdata/purescript-formatters.git",
+    "version": "v4.0.0",
+  }
   "free": {
     "dependencies": [
       "catenable-lists",
@@ -1195,6 +1241,15 @@
     "repo": "https://github.com/purescript-contrib/purescript-react-dom.git",
     "version": "v6.0.0"
   },
+  "read": {
+    "dependencies": [
+      "prelude",
+      "maybe",
+      "strings"
+    ],
+    "repo": "https://github.com/truqu/purescript-read.git",
+    "version": "v1.0.1"
+  },
   "record": {
     "dependencies": [
       "functions",
@@ -1222,6 +1277,16 @@
     ],
     "repo": "https://github.com/purescript/purescript-refs.git",
     "version": "v4.1.0"
+  },
+  "remotedata": {
+    "dependencies": [
+      "bifunctors",
+      "either",
+      "profunctor-lenses",
+      "generics-rep"
+    ],
+    "repo": "https://github.com/krisajenkins/purescript-remotedata.git",
+    "version": "v4.0.0"
   },
   "routing": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -175,7 +175,7 @@
     "dependencies": [
       "maybe",
       "integers",
-      "strings",
+      "strings"
     ],
     "repo": "https://github.com/sharkdp/purescript-bigints.git",
     "version": "v4.0.0"
@@ -507,8 +507,8 @@
       "parsing"
     ],
     "repo": "https://github.com/slamdata/purescript-formatters.git",
-    "version": "v4.0.0",
-  }
+    "version": "v4.0.0"
+  },
   "free": {
     "dependencies": [
       "catenable-lists",

--- a/packages.json
+++ b/packages.json
@@ -341,6 +341,16 @@
     "repo": "https://github.com/purescript/purescript-either.git",
     "version": "v4.0.0"
   },
+  "email-validate": {
+    "dependencies": [
+      "string-parsers",
+      "aff",
+      "transformers",
+      "generics-rep"
+    ],
+    "repo": "https://github.com/cdepillabout/purescript-email-validate.git",
+    "version": "v3.0.0"
+  },
   "enums": {
     "dependencies": [
       "control",

--- a/packages.json
+++ b/packages.json
@@ -341,15 +341,6 @@
     "repo": "https://github.com/purescript/purescript-either.git",
     "version": "v4.0.0"
   },
-  "email-validate": {
-    "dependencies": [
-      "string-parsers",
-      "aff",
-      "transformers"
-    ],
-    "repo": "https://github.com/cdepillabout/purescript-email-validate.git",
-    "version": "v3.0.0"
-  },
   "enums": {
     "dependencies": [
       "control",
@@ -383,10 +374,13 @@
       "effect",
       "filterable",
       "nullable",
-      "prelude"
+      "prelude",
+      "unsafe-reference",
+      "js-timers",
+      "now"
     ],
     "repo": "https://github.com/paf31/purescript-event.git",
-    "version": "v1.0.0"
+    "version": "v1.2.4"
   },
   "exceptions": {
     "dependencies": [
@@ -417,6 +411,16 @@
     ],
     "repo": "https://github.com/LiamGoodacre/purescript-filterable.git",
     "version": "v3.0.0"
+  },
+  "fixed-points": {
+    "dependencies": [
+      "exists",
+      "prelude",
+      "newtype",
+      "transformers"
+    ],
+    "repo": "https://github.com/slamdata/purescript-fixed-points.git",
+    "version": "v5.1.0"
   },
   "foldable-traversable": {
     "dependencies": [
@@ -575,6 +579,22 @@
     "repo": "https://github.com/purescript/purescript-functors.git",
     "version": "v3.0.0"
   },
+  "fuzzy": {
+    "dependencies": [
+      "prelude",
+      "strings",
+      "foldable-traversable",
+      "tuples",
+      "ordered-collections",
+      "newtype",
+      "generics-rep",
+      "rationals",
+      "strongcheck",
+      "foreign-object"
+    ],
+    "repo": "https://github.com/citizennet/purescript-fuzzy.git",
+    "version": "v0.2.1"
+  },
   "gen": {
     "dependencies": [
       "either",
@@ -649,6 +669,13 @@
     ],
     "repo": "https://github.com/slamdata/purescript-halogen-css.git",
     "version": "v8.0.0"
+  },
+  "halogen-select": {
+    "dependencies": [
+      "halogen"
+    ],
+    "repo": "https://github.com/citizennet/purescript-halogen-select.git",
+    "version": "v2.0.0"
   },
   "halogen-vdom": {
     "dependencies": [
@@ -1059,6 +1086,22 @@
     "repo": "https://github.com/purescript/purescript-parallel.git",
     "version": "v4.0.0"
   },
+  "parsing": {
+    "dependencies": [
+      "arrays",
+      "either",
+      "foldable-traversable",
+      "identity",
+      "integers",
+      "lists",
+      "maybe",
+      "strings",
+      "transformers",
+      "unicode"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-parsing.git",
+    "version": "v5.0.1"
+  },
   "partial": {
     "dependencies": [],
     "repo": "https://github.com/purescript/purescript-partial.git",
@@ -1085,6 +1128,22 @@
     ],
     "repo": "https://github.com/felixSchl/purescript-pipes.git",
     "version": "v6.0.0"
+  },
+  "polyform": {
+    "dependencies": [
+      "newtype",
+      "ordered-collections",
+      "generics-rep",
+      "variant",
+      "transformers",
+      "profunctor",
+      "invariant",
+      "run",
+      "foreign",
+      "foreign-object"
+    ],
+    "repo": "https://github.com/paluh/purescript-polyform.git",
+    "version": "v0.7.0"
   },
   "posix-types": {
     "dependencies": [
@@ -1207,6 +1266,14 @@
     "repo": "https://github.com/purescript/purescript-random.git",
     "version": "v4.0.0"
   },
+  "rationals": {
+    "dependencies": [
+      "integers",
+      "prelude"
+    ],
+    "repo": "https://github.com/anttih/purescript-rationals.git",
+    "version": "v5.0.0"
+  },
   "react": {
     "dependencies": [
       "effect",
@@ -1309,6 +1376,25 @@
     "repo": "https://github.com/slamdata/purescript-routing.git",
     "version": "v8.0.0"
   },
+  "run": {
+    "dependencies": [
+      "aff",
+      "either",
+      "free",
+      "maybe",
+      "newtype",
+      "prelude",
+      "tailrec",
+      "tuples",
+      "type-equality",
+      "unsafe-coerce",
+      "variant",
+      "profunctor",
+      "effect"
+    ],
+    "repo": "https://github.com/natefaubion/purescript-run.git",
+    "version": "v2.0.0"
+  },
   "semirings": {
     "dependencies": [
       "foldable-traversable",
@@ -1383,7 +1469,7 @@
       "tailrec"
     ],
     "repo": "https://github.com/paf31/purescript-string-parsers.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "strings": {
     "dependencies": [
@@ -1406,6 +1492,39 @@
     ],
     "repo": "https://github.com/purescript/purescript-strings.git",
     "version": "v4.0.0"
+  },
+  "strongcheck": {
+    "dependencies": [
+      "arrays",
+      "console",
+      "control",
+      "datetime",
+      "effect",
+      "either",
+      "enums",
+      "exceptions",
+      "foldable-traversable",
+      "free",
+      "gen",
+      "identity",
+      "integers",
+      "invariant",
+      "lazy",
+      "lists",
+      "machines",
+      "math",
+      "newtype",
+      "partial",
+      "prelude",
+      "profunctor",
+      "random",
+      "strings",
+      "tailrec",
+      "transformers",
+      "tuples"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-strongcheck.git",
+    "version": "v4.1.1"
   },
   "tailrec": {
     "dependencies": [


### PR DESCRIPTION
This PR adds these repositories into the package set given their 0.12 updates:

- https://github.com/slamdata/purescript-formatters
- https://github.com/sharkdp/purescript-bigints
- https://github.com/paf31/purescript-behaviors
- https://github.com/truqu/purescript-read
- https://github.com/krisajenkins/purescript-remotedata
- https://github.com/cdepillabout/purescript-email-validate