### PR TITLE
Add spec-discovery

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -739,7 +739,7 @@
     "repo": "https://github.com/thomashoneyman/purescript-halogen-formless.git",
     "version": "v0.2.0"
   },
-  "halogen-renderless" : {
+  "halogen-renderless": {
     "dependencies": [
       "control",
       "halogen",

--- a/packages.json
+++ b/packages.json
@@ -1687,6 +1687,17 @@
     "repo": "https://github.com/owickstrom/purescript-spec.git",
     "version": "v3.0.0"
   },
+  "spec-discovery": {
+    "dependencies": [
+      "arrays",
+      "effect",
+      "node-fs",
+      "prelude",
+      "spec"
+    ],
+    "repo": "https://github.com/kazk/purescript-spec-discovery.git",
+    "version": "v3.0.0"
+  },
   "spec-quickcheck": {
     "dependencies": [
       "aff",

--- a/packages.json
+++ b/packages.json
@@ -1695,7 +1695,7 @@
       "prelude",
       "spec"
     ],
-    "repo": "https://github.com/kazk/purescript-spec-discovery.git",
+    "repo": "https://github.com/owickstrom/purescript-spec-discovery.git",
     "version": "v3.0.0"
   },
   "spec-quickcheck": {


### PR DESCRIPTION
> A purescript-spec extension that finds your specs automatically!
> https://github.com/owickstrom/purescript-spec-discovery

~Note that I'm using my fork because the author hasn't responded to [the request to tag the updated version](https://github.com/owickstrom/purescript-spec-discovery/issues/8) opened almost 3 months ago.~