### PR TITLE
Update spec to v3.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1388,7 +1388,6 @@
       "prelude",
       "psci-support",
       "record",
-      "spec",
       "transformers",
       "tuples",
       "typelevel-prelude"

--- a/packages.json
+++ b/packages.json
@@ -1752,8 +1752,8 @@
       "strings",
       "transformers"
     ],
-    "repo": "https://github.com/owickstrom/purescript-spec.git",
-    "version": "v3.0.0"
+    "repo": "https://github.com/purescript-spec/purescript-spec.git",
+    "version": "v3.1.0"
   },
   "spec-discovery": {
     "dependencies": [
@@ -1763,8 +1763,8 @@
       "prelude",
       "spec"
     ],
-    "repo": "https://github.com/owickstrom/purescript-spec-discovery.git",
-    "version": "v3.0.0"
+    "repo": "https://github.com/purescript-spec/purescript-spec-discovery.git",
+    "version": "v3.1.0"
   },
   "spec-quickcheck": {
     "dependencies": [
@@ -1774,8 +1774,8 @@
       "random",
       "spec"
     ],
-    "repo": "https://github.com/owickstrom/purescript-spec-quickcheck.git",
-    "version": "v3.0.0"
+    "repo": "https://github.com/purescript-spec/purescript-spec-quickcheck.git",
+    "version": "v3.1.0"
   },
   "st": {
     "dependencies": [


### PR DESCRIPTION
This PR updates the spec libraries to v3.1.0 and removes a dev dependency from presto.