### PR TITLE
Update `halogen-formless` to latest release (v0.5.2)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -766,7 +766,7 @@
       "variant"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-formless.git",
-    "version": "v0.4.0"
+    "version": "v0.5.2"
   },
   "halogen-renderless": {
     "dependencies": [


### PR DESCRIPTION
A renderless component to build forms in Halogen:
https://github.com/thomashoneyman/purescript-halogen-formless/releases/tag/v0.5.2