### PR TITLE
Add purescript-leibniz to package.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -951,6 +951,14 @@
     "repo": "https://github.com/purescript/purescript-lcg.git",
     "version": "v2.0.0"
   },
+  "leibniz": {
+    "dependencies": [
+      "prelude",
+      "unsafe-coerce"
+    ],
+    "repo": "https://github.com/paf31/purescript-leibniz.git",
+    "version": "v5.0.0"
+  },
   "lists": {
     "dependencies": [
       "bifunctors",


### PR DESCRIPTION
A package with a single module `Data.Leibniz` for expressing type equality.

Pursuit documentation: https://pursuit.purescript.org/packages/purescript-leibniz/5.0.0