### PR TITLE
Add monad-logger v1.0.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,5 +14,8 @@ in pkgs.runCommand "easy-ps-test" {
     purs
     psc-package
     dhall-json-simple;
-  };
+  } ++ [
+    pkgs.dhall
+    pkgs.git
+  ];
 } ""

--- a/default.nix
+++ b/default.nix
@@ -13,9 +13,9 @@ in pkgs.runCommand "easy-ps-test" {
     inherit (easy-ps)
     purs
     psc-package
+    dhall-simple
     dhall-json-simple;
   } ++ [
-    pkgs.dhall
     pkgs.git
   ];
 } ""

--- a/packages.json
+++ b/packages.json
@@ -1242,6 +1242,30 @@
     "repo": "https://github.com/Thimoteus/purescript-mmorph.git",
     "version": "v5.1.0"
   },
+  "monad-logger": {
+    "dependencies": [
+      "aff",
+      "ansi",
+      "argonaut",
+      "arrays",
+      "console",
+      "control",
+      "effect",
+      "foldable-traversable",
+      "foreign-object",
+      "integers",
+      "js-date",
+      "maybe",
+      "newtype",
+      "ordered-collections",
+      "prelude",
+      "strings",
+      "transformers",
+      "tuples"
+    ],
+    "repo": "https://github.com/cprussin/purescript-monad-logger.git",
+    "version": "v1.0.0"
+  },
   "naporitan": {
     "dependencies": [
       "record"

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -34,4 +34,27 @@ in  { httpure =
         ]
         "https://github.com/cprussin/purescript-httpure.git"
         "v0.8.1"
+    , monad-logger =
+        mkPackage
+        [ "aff"
+        , "ansi"
+        , "argonaut"
+        , "arrays"
+        , "console"
+        , "control"
+        , "effect"
+        , "foldable-traversable"
+        , "foreign-object"
+        , "integers"
+        , "js-date"
+        , "maybe"
+        , "newtype"
+        , "ordered-collections"
+        , "prelude"
+        , "strings"
+        , "transformers"
+        , "tuples"
+        ]
+        "https://github.com/cprussin/purescript-monad-logger.git"
+        "v1.0.0"
     }


### PR DESCRIPTION
Add monad-logger v1.0.0.

Also update the `default.nix` file to include some missing dependencies (dhall and git).

Would it be too much to request a release after this is merged in?