### PR TITLE
Clarify requirements for packages being added to the set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,7 @@ It defines some policies that are applied, and details how to add new packages a
 
 All changes go through pull requests.
 
-All packages that are included here must first be published via `bower` with no exceptions. We want to avoid a similar situation that happened in Haskell: a split ecosystem. (If you're unfamiliar with this situation, read [Why not both](https://medium.com/@fommil/why-not-both-8adadb71a5ed) for some context. Their `cabal` is similar to our `bower` and their `stack` is similar to `spago`/`psc-package`.)
-
-Since there are two distribution methods for packages (the Bower registry and the package sets), we rely on the Bower registry to act as a "central registry of package names" for both methods. This prevents divergence in the ecosystem - e.g. having two different codebases for a package called "prelude".
+All packages that are included here must first be published via `bower` with no exceptions. Since there are two distribution methods for packages (the Bower registry and the package sets), we rely on the Bower registry to act as a "central registry of package names" for both methods. This prevents divergence in the ecosystem - e.g. having two different codebases for a package called "prelude".
 
 Packages must comply with the following criteria. The `pulp` commands listed below are used because they handle most of the work for you:
 - `bower i -p` must run successfully.  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ All changes go through pull requests.
 
 All packages that are included here must first be published via `bower` with no exceptions. We want to avoid a similar situation that happened in Haskell: a split ecosystem. (If you're unfamiliar with this situation, read [Why not both](https://medium.com/@fommil/why-not-both-8adadb71a5ed) for some context. Their `cabal` is similar to our `bower` and their `stack` is similar to `spago`/`psc-package`.)
 
-Since there are two distribution methods for packages (the Bower registry and the package sets), we rely on the Bower registry to act as a "central registry of package names" for both methods. This prevents divergence in the ecosystem similar to the Haskell situation described above (e.g. having two different codebases for a package called "prelude").
+Since there are two distribution methods for packages (the Bower registry and the package sets), we rely on the Bower registry to act as a "central registry of package names" for both methods. This prevents divergence in the ecosystem - e.g. having two different codebases for a package called "prelude".
 
 Packages must comply with the following criteria. The `pulp` commands listed below are used because they handle most of the work for you:
 - `bower i -p` must run successfully.  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,17 @@ It defines some policies that are applied, and details how to add new packages a
 
 All changes go through pull requests.
 
-There are some criteria that packages being added should comply with:
-- _You should use `pulp version` to version your package._  
-  The reason is that the tag should start with the `v` prefix
-- _You should use `pulp publish` to publish your package._  
-  The reason is that since there are two distribution methods for packages (the Bower registry and the package sets), we rely on the Bower registry to act as a "central registry of package names" for both methods, in order to prevent divergence in the ecosystem (e.g. having two different codebases for a package called "prelude")
-- `bower i -p` should run successfully
+All packages that are included here must first be published via `bower` with no exceptions. We want to avoid a similar situation that happened in Haskell: a split ecosystem. (If you're unfamiliar with this situation, read [Why not both](https://medium.com/@fommil/why-not-both-8adadb71a5ed) for some context. Their `cabal` is similar to our `bower` and their `stack` is similar to `spago`/`psc-package`.)
+
+Since there are two distribution methods for packages (the Bower registry and the package sets), we rely on the Bower registry to act as a "central registry of package names" for both methods. This prevents divergence in the ecosystem similar to the Haskell situation described above (e.g. having two different codebases for a package called "prelude").
+
+Packages must comply with the following criteria. The `pulp` commands listed below are used because they handle most of the work for you:
+- `bower i -p` must run successfully.  
+  This command installs your dependencies and excludes any 'devDependencies'.
+- _You must use `pulp version` to version your package._  
+  This guarantees that the tag will start with the `v` prefix.
+- _You must use `pulp publish` to publish your package._  
+  This command will handle all of the publishing work for you. 
 
 ## Releases
 


### PR DESCRIPTION
@f-f As promised in [my comment](https://github.com/spacchetti/spago/issues/142#issuecomment-475465232)

Is there anything else we want to change here to make things clearer? For example, while `pulp version` may handle the "v" prefix, are there any other requirements (e.g. use semver for versioning)?