### PR TITLE
Re-add node-electron

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1442,6 +1442,23 @@
     "repo": "https://github.com/purescript-node/purescript-node-child-process.git",
     "version": "v6.0.0"
   },
+  "node-electron": {
+    "dependencies": [
+      "effect",
+      "foreign",
+      "halogen",
+      "maybe",
+      "options",
+      "prelude",
+      "transformers",
+      "unsafe-coerce",
+      "web-dom",
+      "web-events",
+      "web-html"
+    ],
+    "repo": "https://github.com/cprussin/purescript-node-electron.git",
+    "version": "v0.0.2"
+  },
   "node-fs": {
     "dependencies": [
       "datetime",

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -57,4 +57,20 @@ in  { httpure =
         ]
         "https://github.com/cprussin/purescript-monad-logger.git"
         "v1.1.0"
+    , node-electron =
+        mkPackage
+        [ "effect"
+        , "foreign"
+        , "halogen"
+        , "maybe"
+        , "options"
+        , "prelude"
+        , "transformers"
+        , "unsafe-coerce"
+        , "web-dom"
+        , "web-events"
+        , "web-html"
+        ]
+        "https://github.com/cprussin/purescript-node-electron.git"
+        "v0.0.2"
     }


### PR DESCRIPTION
@justinwoo I somehow didn't ever see your [request to publish this package to bower](https://github.com/cprussin/purescript-node-electron/issues/1) and I just noticed that the package got dropped from the package set.  My apologies on missing that ticket!

I just revved the package and published to bower (I did not use `pulp version` since I'm running into the OOM issue that I understand is being worked on in pulp--let me know if that's a problem), I'd love to get this re-added to the package set now.  Thanks a bunch!