### PR TITLE
 changed `/bin/bash` to `/usr/bin/env bash`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ format:
 	@find src/ -iname "*.dhall" -exec dhall format --inplace {} \;
 	@echo formatted dhall files
 
-generate: SHELL:=/bin/bash
+generate: SHELL:=/usr/bin/env bash
 generate:
 	@dhall-to-json --pretty <<< "./src/packages.dhall" > packages.json
 	@psc-package format


### PR DESCRIPTION
Can we have this little change to ensure compatibility with systems that use non-standard paths, e.g. NixOS?