### PR TITLE
Add bytestrings, quotient, and postgresql-client from rightfold

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1846,33 +1846,6 @@
     "repo": "https://github.com/purescript-node/purescript-posix-types.git",
     "version": "v4.0.0"
   },
-  "postgresql-client": {
-    "dependencies": [
-      "aff",
-      "arrays",
-      "bifunctors",
-      "bytestrings",
-      "datetime",
-      "decimals",
-      "effect",
-      "either",
-      "exceptions",
-      "foldable-traversable",
-      "foreign",
-      "foreign-generic",
-      "foreign-object",
-      "js-date",
-      "lists",
-      "maybe",
-      "newtype",
-      "nullable",
-      "prelude",
-      "transformers",
-      "tuples"
-    ],
-    "repo": "https://github.com/rightfold/purescript-postgresql-client",
-    "version": "v3.0.0-alpha"
-  },
   "prelude": {
     "dependencies": [],
     "repo": "https://github.com/purescript/purescript-prelude.git",

--- a/packages.json
+++ b/packages.json
@@ -353,6 +353,25 @@
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-static.git",
     "version": "v0.2.0"
   },
+  "bytestrings": {
+    "dependencies": [
+      "arrays",
+      "effect",
+      "exceptions",
+      "foldable-traversable",
+      "integers",
+      "leibniz",
+      "maybe",
+      "newtype",
+      "node-buffer",
+      "prelude",
+      "quickcheck",
+      "quotient",
+      "unsafe-coerce"
+    ],
+    "repo": "https://github.com/rightfold/purescript-bytestrings.git",
+    "version": "v7.0.0"
+  },
   "canvas": {
     "dependencies": [
       "arraybuffer-types",
@@ -1827,6 +1846,33 @@
     "repo": "https://github.com/purescript-node/purescript-posix-types.git",
     "version": "v4.0.0"
   },
+  "postgresql-client": {
+    "dependencies": [
+      "aff",
+      "arrays",
+      "bifunctors",
+      "bytestrings",
+      "datetime",
+      "decimals",
+      "effect",
+      "either",
+      "exceptions",
+      "foldable-traversable",
+      "foreign",
+      "foreign-generic",
+      "foreign-object",
+      "js-date",
+      "lists",
+      "maybe",
+      "newtype",
+      "nullable",
+      "prelude",
+      "transformers",
+      "tuples"
+    ],
+    "repo": "https://github.com/rightfold/purescript-postgresql-client",
+    "version": "v3.0.0-alpha"
+  },
   "prelude": {
     "dependencies": [],
     "repo": "https://github.com/purescript/purescript-prelude.git",
@@ -1951,6 +1997,15 @@
     ],
     "repo": "https://github.com/garyb/purescript-quickcheck-laws.git",
     "version": "v5.0.1"
+  },
+  "quotient": {
+    "dependencies": [
+      "prelude",
+      "proxy",
+      "quickcheck"
+    ],
+    "repo": "https://github.com/rightfold/purescript-quotient.git",
+    "version": "v3.0.0"
   },
   "random": {
     "dependencies": [

--- a/src/groups/rightfold.dhall
+++ b/src/groups/rightfold.dhall
@@ -18,32 +18,6 @@ in  { bytestrings =
         ]
         "https://github.com/rightfold/purescript-bytestrings.git"
         "v7.0.0"
-    , postgresql-client =
-        mkPackage
-        [ "prelude"
-        , "transformers"
-        , "lists"
-        , "foreign"
-        , "aff"
-        , "either"
-        , "maybe"
-        , "foldable-traversable"
-        , "newtype"
-        , "bytestrings"
-        , "arrays"
-        , "datetime"
-        , "bifunctors"
-        , "effect"
-        , "exceptions"
-        , "decimals"
-        , "js-date"
-        , "foreign-object"
-        , "foreign-generic"
-        , "tuples"
-        , "nullable"
-        ]
-        "https://github.com/rightfold/purescript-postgresql-client"
-        "v3.0.0-alpha"
     , quotient =
         mkPackage
         [ "prelude", "proxy", "quickcheck" ]

--- a/src/groups/rightfold.dhall
+++ b/src/groups/rightfold.dhall
@@ -1,0 +1,52 @@
+let mkPackage = ./../mkPackage.dhall
+
+in  { bytestrings =
+        mkPackage
+        [ "node-buffer"
+        , "prelude"
+        , "effect"
+        , "quickcheck"
+        , "maybe"
+        , "arrays"
+        , "leibniz"
+        , "foldable-traversable"
+        , "unsafe-coerce"
+        , "newtype"
+        , "integers"
+        , "quotient"
+        , "exceptions"
+        ]
+        "https://github.com/rightfold/purescript-bytestrings.git"
+        "v7.0.0"
+    , postgresql-client =
+        mkPackage
+        [ "prelude"
+        , "transformers"
+        , "lists"
+        , "foreign"
+        , "aff"
+        , "either"
+        , "maybe"
+        , "foldable-traversable"
+        , "newtype"
+        , "bytestrings"
+        , "arrays"
+        , "datetime"
+        , "bifunctors"
+        , "effect"
+        , "exceptions"
+        , "decimals"
+        , "js-date"
+        , "foreign-object"
+        , "foreign-generic"
+        , "tuples"
+        , "nullable"
+        ]
+        "https://github.com/rightfold/purescript-postgresql-client"
+        "v3.0.0-alpha"
+    , quotient =
+        mkPackage
+        [ "prelude", "proxy", "quickcheck" ]
+        "https://github.com/rightfold/purescript-quotient.git"
+        "v3.0.0"
+    }

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -53,6 +53,7 @@ let packages =
       ⫽ ./groups/purescript-freedom.dhall
       ⫽ ./groups/purescript-spec.dhall
       ⫽ ./groups/reactormonk.dhall
+      ⫽ ./groups/rightfold.dhall
       ⫽ ./groups/rnons.dhall
       ⫽ ./groups/sharkdp.dhall
       ⫽ ./groups/slamdata.dhall


### PR DESCRIPTION
I need `postgresql-client`, and the others (`bytestrings` and `quotient`) are dependencies.