### PR TITLE
Update httpure to v0.8.3

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1151,7 +1151,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/cprussin/purescript-httpure.git",
-    "version": "v0.8.2"
+    "version": "v0.8.3"
   },
   "identity": {
     "dependencies": [

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -34,7 +34,7 @@ in  { httpure =
         , "unsafe-coerce"
         ]
         "https://github.com/cprussin/purescript-httpure.git"
-        "v0.8.2"
+        "v0.8.3"
     , monad-logger =
         mkPackage
         [ "aff"


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/cprussin/purescript-httpure/releases/tag/v0.8.3