### PR TITLE
Update milkis to v7.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1390,7 +1390,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-milkis.git",
-    "version": "v7.0.0"
+    "version": "v7.0.1"
   },
   "minibench": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -29,7 +29,7 @@ in  { gomtang-basic =
         , "typelevel-prelude"
         ]
         "https://github.com/justinwoo/purescript-milkis.git"
-        "v7.0.0"
+        "v7.0.1"
     , node-he =
         mkPackage
         ([] : List Text)


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-milkis/releases/tag/v7.0.1