### PR TITLE
Update mysql to v2.1.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1463,7 +1463,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-mysql.git",
-    "version": "v2.1.0"
+    "version": "v2.1.1"
   },
   "naporitan": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -19,7 +19,7 @@ in  { basic-auth =
         mkPackage
         [ "aff", "js-date", "simple-json" ]
         "https://github.com/oreshinya/purescript-mysql.git"
-        "v2.1.0"
+        "v2.1.1"
     , nodemailer =
         mkPackage
         [ "aff", "node-streams", "simple-json" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-mysql/releases/tag/v2.1.1