### PR TITLE
Update identy to v2.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1178,7 +1178,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-identy.git",
-    "version": "v2.0.0"
+    "version": "v2.0.1"
   },
   "indexed-monad": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -14,7 +14,7 @@ in  { basic-auth =
         mkPackage
         [ "simple-json" ]
         "https://github.com/oreshinya/purescript-identy.git"
-        "v2.0.0"
+        "v2.0.1"
     , mysql =
         mkPackage
         [ "aff", "js-date", "simple-json" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-identy/releases/tag/v2.0.1