### PR TITLE
Update nodemailer to v2.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1671,7 +1671,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-nodemailer.git",
-    "version": "v2.0.0"
+    "version": "v2.0.1"
   },
   "nonempty": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -24,7 +24,7 @@ in  { basic-auth =
         mkPackage
         [ "aff", "node-streams", "simple-json" ]
         "https://github.com/oreshinya/purescript-nodemailer.git"
-        "v2.0.0"
+        "v2.0.1"
     , simple-emitter =
         mkPackage
         [ "ordered-collections", "refs" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-nodemailer/releases/tag/v2.0.1