### PR TITLE
Add purescript-metadata package to track the compiler version

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1390,6 +1390,11 @@
     "repo": "https://github.com/paf31/purescript-memoize.git",
     "version": "v5.0.0"
   },
+  "metadata": {
+    "dependencies": [],
+    "repo": "https://github.com/spacchetti/purescript-metadata.git",
+    "version": "v0.13.0"
+  },
   "milkis": {
     "dependencies": [
       "aff-promise",

--- a/src/groups/spacchetti.dhall
+++ b/src/groups/spacchetti.dhall
@@ -1,0 +1,8 @@
+let mkPackage = ./../mkPackage.dhall
+
+in  { metadata =
+        mkPackage
+        ([] : List Text)
+        "https://github.com/spacchetti/purescript-metadata.git"
+        "v0.13.0"
+    }

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -57,6 +57,7 @@ let packages =
       ⫽ ./groups/rnons.dhall
       ⫽ ./groups/sharkdp.dhall
       ⫽ ./groups/slamdata.dhall
+      ⫽ ./groups/spacchetti.dhall
       ⫽ ./groups/spicydonuts.dhall
       ⫽ ./groups/truqu.dhall
       ⫽ ./groups/zaquest.dhall


### PR DESCRIPTION
Fix #96 by adding a bogus package having the same SemVer as the compiler, so that tools can make use of this information.

If we'll need more metadata about the compiler and/or the package set we can always add it _inside_ this package.