### PR TITLE
Update node-readline to v4.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1631,7 +1631,7 @@
       "prelude"
     ],
     "repo": "https://github.com/purescript-node/purescript-node-readline.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "node-sqlite3": {
     "dependencies": [

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -92,7 +92,7 @@ in  { node-buffer =
         , "prelude"
         ]
         "https://github.com/purescript-node/purescript-node-readline.git"
-        "v4.0.0"
+        "v4.0.1"
     , node-streams =
         mkPackage
         [ "effect", "either", "exceptions", "node-buffer", "prelude" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-node/purescript-node-readline/releases/tag/v4.0.1