### PR TITLE
Update spec-discovery to v4.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2422,7 +2422,7 @@
       "spec"
     ],
     "repo": "https://github.com/owickstrom/purescript-spec-discovery.git",
-    "version": "v3.2.0"
+    "version": "v4.0.0"
   },
   "spec-quickcheck": {
     "dependencies": [

--- a/src/groups/owickstrom.dhall
+++ b/src/groups/owickstrom.dhall
@@ -4,7 +4,7 @@ in  { spec-discovery =
         mkPackage
         [ "arrays", "effect", "node-fs", "prelude", "spec" ]
         "https://github.com/owickstrom/purescript-spec-discovery.git"
-        "v3.2.0"
+        "v4.0.0"
     , spec-quickcheck =
         mkPackage
         [ "aff", "prelude", "quickcheck", "random", "spec" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/owickstrom/purescript-spec-discovery/releases/tag/v4.0.0