### PR TITLE
Update foreign-object to v2.0.3

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -810,7 +810,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/purescript/purescript-foreign-object.git",
-    "version": "v2.0.2"
+    "version": "v2.0.3"
   },
   "fork": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -166,7 +166,7 @@ in  { arrays =
         , "unfoldable"
         ]
         "https://github.com/purescript/purescript-foreign-object.git"
-        "v2.0.2"
+        "v2.0.3"
     , free =
         mkPackage
         [ "catenable-lists"


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript/purescript-foreign-object/releases/tag/v2.0.3