### PR TITLE
Update react-basic-hooks to v0.7.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2072,7 +2072,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v0.6.1"
+    "version": "v0.7.1"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -10,5 +10,5 @@ in  { react-basic-hooks =
         , "unsafe-reference"
         ]
         "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-        "v0.6.1"
+        "v0.7.1"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v0.7.1