### PR TITLE
Update sunde to v2.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2598,7 +2598,7 @@
       "prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-sunde.git",
-    "version": "v1.0.0"
+    "version": "v2.0.0"
   },
   "svg-parser": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -69,7 +69,7 @@ in  { gomtang-basic =
         mkPackage
         [ "aff", "effect", "node-child-process", "prelude" ]
         "https://github.com/justinwoo/purescript-sunde.git"
-        "v1.0.0"
+        "v2.0.0"
     , toppokki =
         mkPackage
         [ "aff-promise"


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-sunde/releases/tag/v2.0.0