### PR TITLE
Update format-nix to v0.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -864,7 +864,7 @@
       "prelude"
     ],
     "repo": "https://github.com/justinwoo/format-nix.git",
-    "version": "v0.1.1"
+    "version": "v0.2.0"
   },
   "formatters": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -171,5 +171,5 @@ in  { gomtang-basic =
         mkPackage
         [ "generics-rep", "motsunabe", "prelude" ]
         "https://github.com/justinwoo/format-nix.git"
-        "v0.1.1"
+        "v0.2.0"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-format-nix/releases/tag/v0.2.0