### PR TITLE
Update stringutils to v0.0.9

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2555,7 +2555,7 @@
       "strings"
     ],
     "repo": "https://github.com/menelaos/purescript-stringutils.git",
-    "version": "v0.0.8"
+    "version": "v0.0.9"
   },
   "strongcheck": {
     "dependencies": [

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -30,5 +30,5 @@ in  { b64 =
         , "integers"
         ]
         "https://github.com/menelaos/purescript-stringutils.git"
-        "v0.0.8"
+        "v0.0.9"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/menelaos/purescript-stringutils/releases/tag/v0.0.9