### PR TITLE
Update record-format to v2.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2161,7 +2161,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/kcsongor/purescript-record-format.git",
-    "version": "v1.0.0"
+    "version": "v2.0.0"
   },
   "redux-devtools": {
     "dependencies": [

--- a/src/groups/kcsongor.dhall
+++ b/src/groups/kcsongor.dhall
@@ -4,5 +4,5 @@ in  { record-format =
         mkPackage
         [ "record", "strings", "typelevel-prelude" ]
         "https://github.com/kcsongor/purescript-record-format.git"
-        "v1.0.0"
+        "v2.0.0"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/kcsongor/purescript-record-format/releases/tag/v2.0.0