### PR TITLE
Update mysql to v3.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1495,7 +1495,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-mysql.git",
-    "version": "v3.0.0"
+    "version": "v3.0.1"
   },
   "naporitan": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -19,7 +19,7 @@ in  { basic-auth =
         mkPackage
         [ "aff", "js-date", "simple-json" ]
         "https://github.com/oreshinya/purescript-mysql.git"
-        "v3.0.0"
+        "v3.0.1"
     , nodemailer =
         mkPackage
         [ "aff", "node-streams", "simple-json" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-mysql/releases/tag/v3.0.1