### PR TITLE
Update simple-jwt to v1.0.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2461,7 +2461,7 @@
       "strings"
     ],
     "repo": "https://github.com/oreshinya/purescript-simple-jwt.git",
-    "version": "v1.0.1"
+    "version": "v1.0.2"
   },
   "sized-vectors": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -34,5 +34,5 @@ in  { basic-auth =
         mkPackage
         [ "crypto", "simple-json", "strings" ]
         "https://github.com/oreshinya/purescript-simple-jwt.git"
-        "v1.0.1"
+        "v1.0.2"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-simple-jwt/releases/tag/v1.0.2