### PR TITLE
Update bucketchain-simple-api to v0.4.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -343,7 +343,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git",
-    "version": "v0.4.1"
+    "version": "v0.4.2"
   },
   "bucketchain-sslify": {
     "dependencies": [

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -54,7 +54,7 @@ in  { bucketchain =
         mkPackage
         [ "bucketchain", "media-types", "simple-json" ]
         "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git"
-        "v0.4.1"
+        "v0.4.2"
     , bucketchain-sslify =
         mkPackage
         [ "bucketchain" ]


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Bucketchain/purescript-bucketchain-simple-api/releases/tag/v0.4.2