### PR TITLE
Update spec to v4.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2528,7 +2528,7 @@
       "transformers"
     ],
     "repo": "https://github.com/purescript-spec/purescript-spec.git",
-    "version": "v4.0.0-rc1"
+    "version": "v4.0.0"
   },
   "spec-discovery": {
     "dependencies": [

--- a/src/groups/purescript-spec.dhall
+++ b/src/groups/purescript-spec.dhall
@@ -17,5 +17,5 @@ in  { spec =
         , "transformers"
         ]
         "https://github.com/purescript-spec/purescript-spec.git"
-        "v4.0.0-rc1"
+        "v4.0.0"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-spec/purescript-spec/releases/tag/v4.0.0