### PR TITLE
Update format-nix to v0.3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -871,7 +871,7 @@
       "prelude"
     ],
     "repo": "https://github.com/justinwoo/format-nix.git",
-    "version": "v0.2.0"
+    "version": "v0.3.0"
   },
   "formatters": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -171,5 +171,5 @@ in  { gomtang-basic =
         mkPackage
         [ "generics-rep", "motsunabe", "prelude" ]
         "https://github.com/justinwoo/format-nix.git"
-        "v0.2.0"
+        "v0.3.0"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-format-nix/releases/tag/v0.3.0