### PR TITLE
Add hashes when importing groups to speedup download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all: format generate
 
 format:
 	@find src/ -iname "*.dhall" -exec dhall format --inplace {} \;
+	dhall freeze --all --inplace src/packages.dhall
 	@echo formatted dhall files
 
 generate: SHELL:=/usr/bin/env bash

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: format generate
 
 format:
 	@find src/ -iname "*.dhall" -exec dhall format --inplace {} \;
-	dhall freeze --all --inplace src/packages.dhall
+	@dhall freeze --all --inplace src/packages.dhall
 	@echo formatted dhall files
 
 generate: SHELL:=/usr/bin/env bash

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -1,69 +1,69 @@
 let packages =
-        ./groups/purescript.dhall
-      ⫽ ./groups/purescript-contrib.dhall
-      ⫽ ./groups/purescript-web.dhall
-      ⫽ ./groups/purescript-node.dhall
-      ⫽ ./groups/ad-si.dhall
-      ⫽ ./groups/alexadewit.dhall
-      ⫽ ./groups/liamgoodacre.dhall
-      ⫽ ./groups/lukajcb.dhall
-      ⫽ ./groups/michaelxavier.dhall
-      ⫽ ./groups/sodiumfrp.dhall
-      ⫽ ./groups/thimoteus.dhall
-      ⫽ ./groups/adkelley.dhall
-      ⫽ ./groups/ajnsit.dhall
-      ⫽ ./groups/athanclark.dhall
-      ⫽ ./groups/anttih.dhall
-      ⫽ ./groups/bodil.dhall
-      ⫽ ./groups/brandonhamilton.dhall
-      ⫽ ./groups/bucketchain.dhall
-      ⫽ ./groups/cdepillabout.dhall
-      ⫽ ./groups/citizennet.dhall
-      ⫽ ./groups/cprussin.dhall
-      ⫽ ./groups/danieljharvey.dhall
-      ⫽ ./groups/epost.dhall
-      ⫽ ./groups/ethul.dhall
-      ⫽ ./groups/fehrenbach.dhall
-      ⫽ ./groups/felixschl.dhall
-      ⫽ ./groups/felixmulder.dhall
-      ⫽ ./groups/garyb.dhall
-      ⫽ ./groups/gcanti.dhall
-      ⫽ ./groups/hdgarrood.dhall
-      ⫽ ./groups/i-am-tom.dhall
-      ⫽ ./groups/icyrockcom.dhall
-      ⫽ ./groups/jacereda.dhall
-      ⫽ ./groups/juspay.dhall
-      ⫽ ./groups/justinwoo.dhall
-      ⫽ ./groups/kcsongor.dhall
-      ⫽ ./groups/klntsky.dhall
-      ⫽ ./groups/krisajenkins.dhall
-      ⫽ ./groups/kritzcreek.dhall
-      ⫽ ./groups/lumihq.dhall
-      ⫽ ./groups/menelaos.dhall
-      ⫽ ./groups/morganthomas.dhall
-      ⫽ ./groups/mschristiansen.dhall
-      ⫽ ./groups/natefaubion.dhall
-      ⫽ ./groups/nkly.dhall
-      ⫽ ./groups/nsaunders.dhall
-      ⫽ ./groups/nwolverson.dhall
-      ⫽ ./groups/oreshinya.dhall
-      ⫽ ./groups/owickstrom.dhall
-      ⫽ ./groups/paf31.dhall
-      ⫽ ./groups/paluh.dhall
-      ⫽ ./groups/passy.dhall
-      ⫽ ./groups/purescript-freedom.dhall
-      ⫽ ./groups/purescript-spec.dhall
-      ⫽ ./groups/reactormonk.dhall
-      ⫽ ./groups/rightfold.dhall
-      ⫽ ./groups/rnons.dhall
-      ⫽ ./groups/sharkdp.dhall
-      ⫽ ./groups/slamdata.dhall
-      ⫽ ./groups/spacchetti.dhall
-      ⫽ ./groups/spicydonuts.dhall
-      ⫽ ./groups/truqu.dhall
-      ⫽ ./groups/zaquest.dhall
-      ⫽ ./groups/dwhitney.dhall
-      ⫽ ./groups/f-o-a-m.dhall
-      ⫽ ./groups/risto-stevcev.dhall
+        ./groups/purescript.dhall sha256:ae3da6b86c781a904f448ee6d48c377b30a7c7c28ae963b41eeda0539ac3f2cb
+      ⫽ ./groups/purescript-contrib.dhall sha256:99066e76dc6cbc2d393ae9d62179ebeac510e970ddc05d8b261862b746dc1a8c
+      ⫽ ./groups/purescript-web.dhall sha256:e3e7e9922d53fa4d6bcdd670f35d232de42780766feee09a79723a76c572ec5b
+      ⫽ ./groups/purescript-node.dhall sha256:a800e19ea56bb5ef5db241c1d5eaaf9e9a690ed5e193f8ef010f1799199d43f4
+      ⫽ ./groups/ad-si.dhall sha256:d3eb3377512a930d89ce64740cac962f33e9ecb5d8d4d5eb3e33fd0fb4d539b2
+      ⫽ ./groups/alexadewit.dhall sha256:c982c400654e5b4d7af91be0c44e36742c8875b078edb39e88e0dc1289ee07d9
+      ⫽ ./groups/liamgoodacre.dhall sha256:0945e9c879fda9034d73afe96c38c5d2543156cd9b7f5e88120059234dc70939
+      ⫽ ./groups/lukajcb.dhall sha256:edda46520c0d484339849ba566ea19264c9d08c98c2725a97b339b4f65ecbb52
+      ⫽ ./groups/michaelxavier.dhall sha256:ce07fba394258c793ec4713dfa72ca05c0842527745bf183de37780019d98f3b
+      ⫽ ./groups/sodiumfrp.dhall sha256:1ef1585906de97d4c842812411d66781f5b976e152a72a3889f07fb3ff981cdd
+      ⫽ ./groups/thimoteus.dhall sha256:fe6b37aea5bd48e62ae8c360899cc5b3462712d43fa7a4576b9742c9f7701cb9
+      ⫽ ./groups/adkelley.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
+      ⫽ ./groups/ajnsit.dhall sha256:3cfc89744bbf059542efe4b32fc5972852e150b66828de1ea73175ab7d496d29
+      ⫽ ./groups/athanclark.dhall sha256:789e7aa87b0290a029927ff0be362e0dce1c9ae2a861c1ee997899b17ff7241b
+      ⫽ ./groups/anttih.dhall sha256:fd1730256d9ffe106e6899ffa7e9a7fcc77571949fce5d9e3f363f3f114be45c
+      ⫽ ./groups/bodil.dhall sha256:a60df1b1d43c8d2aa82fb9c98d88316ce8db6170bb65073bb86ef39d841881d9
+      ⫽ ./groups/brandonhamilton.dhall sha256:2dfc0ba893d8c01cbdfa963f35d5fa8b1523929011c67aa4da26c8eda512f609
+      ⫽ ./groups/bucketchain.dhall sha256:c6c96eb5122c61248fca62a29fce7fd4bea5095b315865a5ae8e557868cf4bfe
+      ⫽ ./groups/cdepillabout.dhall sha256:29d6005a2aa236b917865eecc9f166699f328672f18a789cdab3bf9146b2b9d4
+      ⫽ ./groups/citizennet.dhall sha256:a3fb313db0ec4f461a56f0e8cd491911d70633ddade82e695c4f14bb2e165f05
+      ⫽ ./groups/cprussin.dhall sha256:476c1e32520ad4ee640453c7b7476857a59b23693f76a28eb72523426f20b2dd
+      ⫽ ./groups/danieljharvey.dhall sha256:2112114a857a865e57c7964678e67491a3841e9cdc39c42cd463e1c8ad0330cd
+      ⫽ ./groups/epost.dhall sha256:e7f45242606aa7c1518da8d019bc29c3c09ccf0122fb904e778c6063dd8f9b27
+      ⫽ ./groups/ethul.dhall sha256:440a85363b02907d6533e6748d02568368f3e09ac37be2b74f8c552387ff2c1f
+      ⫽ ./groups/fehrenbach.dhall sha256:29a27210dea836459250d2e80f440cd8ac4a51c46b433729623a08eabe73de93
+      ⫽ ./groups/felixschl.dhall sha256:aa0805cf88905343aed95c5079b82aa197493b94f94b9a822f301a74d7dab136
+      ⫽ ./groups/felixmulder.dhall sha256:0c6d60760e32acd9729e1f78844b2234e9a643acab584c98b6c63f35cd1944ac
+      ⫽ ./groups/garyb.dhall sha256:b74fec236308d62bd1ac407ab263eef94569bffc5a13f0f50d8e44e41b35eb8e
+      ⫽ ./groups/gcanti.dhall sha256:36bd0711a1efacf6f3e094d5d5ac7c2d7b4f5c4e11838581c77b1b3fca4e1d76
+      ⫽ ./groups/hdgarrood.dhall sha256:48b1c485491ff7e647d95fceacba40fe8ab50ba04526ee2204cc614cbb5541f0
+      ⫽ ./groups/i-am-tom.dhall sha256:6a5e128f5ed3e83dc30f5697f029afdeb692f22f41a4aab932c4bfa2eb422885
+      ⫽ ./groups/icyrockcom.dhall sha256:6f27904a222c60a990e40218387f477bc4d7d3ae56ff910a859eb9f819850024
+      ⫽ ./groups/jacereda.dhall sha256:a82b62bd790d50bc730ad8abc7d314ec2917715e20b79b6318b4b602bce6524e
+      ⫽ ./groups/juspay.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
+      ⫽ ./groups/justinwoo.dhall sha256:96b267244e2b5279e4c9194b6739718949e6425cf0ac36aa27171c1db41fcd84
+      ⫽ ./groups/kcsongor.dhall sha256:68b5eddc5ce2012c741537d3e11201f04a0170deb0c6bf5271f6a19a1fb62b14
+      ⫽ ./groups/klntsky.dhall sha256:85c5759f1813a878763c68e8eb2df8f3ec8bf031bff7600e95b9531eae83116a
+      ⫽ ./groups/krisajenkins.dhall sha256:838cbfe7b77dfcfb47551a031438100bb008df8c6b6483c1509772a75d6bfd03
+      ⫽ ./groups/kritzcreek.dhall sha256:139951c67612bd373e4bd8f448120938096d4d5df8afc6206af2b34b6285f229
+      ⫽ ./groups/lumihq.dhall sha256:8e21697c4c0b74ded7f3614c24adf10833cd2d4d1b50e2762b874ec277aa94a6
+      ⫽ ./groups/menelaos.dhall sha256:3213a54c820b0f19c60e5b94bb6ee33be3399d81d663f3ddb7c7ff4ffda094df
+      ⫽ ./groups/morganthomas.dhall sha256:b8b51a988bafcfabf890c80dfd8e24d84286cb0d1e4043c6a945b311f2a6dfe7
+      ⫽ ./groups/mschristiansen.dhall sha256:780ebeb7efa84796edcb45f03b589c7611d55be07ecf37a1c86e5faefbb12ad8
+      ⫽ ./groups/natefaubion.dhall sha256:da088db0591ca741b5b89959269aec1c8d1cc5ee4a520cfaf9953a5aa5f44eae
+      ⫽ ./groups/nkly.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
+      ⫽ ./groups/nsaunders.dhall sha256:4c6267557912d5410ba2b4fe4df6b311c5f3d85bd6b16b92308f190418f69f4b
+      ⫽ ./groups/nwolverson.dhall sha256:2e955121b2839361edb787d554c6ea731e2b39bc354202a3933da5ffbce93a87
+      ⫽ ./groups/oreshinya.dhall sha256:de9a180811060a9df03f209ec8a3a3d792ddc41bcba0c80b4a1d3d1977bcdb7b
+      ⫽ ./groups/owickstrom.dhall sha256:4d4b5eec9e1ffd21ddfe45f65179c4ad6971953c58412af33c74322522275d76
+      ⫽ ./groups/paf31.dhall sha256:c258150860880b194f7e933135e8705c503a3de61c3ca55706c035aaa7e13b76
+      ⫽ ./groups/paluh.dhall sha256:851aaf6de67056b5ff1c01e5c7c4eaa260e9384d217c5ef573c11eff1e18398b
+      ⫽ ./groups/passy.dhall sha256:f16b1b87991f2b03804e3a0f1f2812d79dbeeac593811a8c246a7025520c8cde
+      ⫽ ./groups/purescript-freedom.dhall sha256:27320387a19e1c12f01960f121196cdde768cea01b364731e9316082ad7631bf
+      ⫽ ./groups/purescript-spec.dhall sha256:0b666e1fbd314bf62d842fdbbf5e41e8c97aa68c7ba1f7e88a969fbe0f687b23
+      ⫽ ./groups/reactormonk.dhall sha256:3af16df4a4bc5ef5f076270532b4bf66ea647169557faf6f2e66fdb831578fa5
+      ⫽ ./groups/rightfold.dhall sha256:fcc425bd0f37a7272341743ba23de1fa9afe69ba2fb03325ef1262c6fdb60f51
+      ⫽ ./groups/rnons.dhall sha256:0d1f8201ce7094435c2695074c963c9e7e80a2b49839b6748515eda89da66d88
+      ⫽ ./groups/sharkdp.dhall sha256:62ec96b8e487d45047cba0c26bf428b503a16fd76f62c041bc567ed9322ddb73
+      ⫽ ./groups/slamdata.dhall sha256:2a51520a0473a97e29021176953bfbb6a1c6c575cb4c49c547a01844dd7fa4b8
+      ⫽ ./groups/spacchetti.dhall sha256:c255e2525c04581c7ffbb2ec3cf493512e05825558819d32e4a09d4af94f13ba
+      ⫽ ./groups/spicydonuts.dhall sha256:a2392619c0b6b2e2b3ccb808c5487afb4918b8769887f67b629e83be5475c6e1
+      ⫽ ./groups/truqu.dhall sha256:fc2ecdd4226de3453f44c4280c1741b43f02eec1bd433772be29ea81cfdf4cb5
+      ⫽ ./groups/zaquest.dhall sha256:2c975529aa9e0b73dc9056c6d65d5f9c3f261e5faf96568166406645714fb9e5
+      ⫽ ./groups/dwhitney.dhall sha256:8245313a89a076f2f5f4145f6e28b807a291ec09c3ecd20c67867a89a2c7ca3f
+      ⫽ ./groups/f-o-a-m.dhall sha256:26ee982784a4f27be8766f8ce599eb4e79a12a2e3d1b5504a6c0d4060e0d8503
+      ⫽ ./groups/risto-stevcev.dhall sha256:54f4dad416be1f64ef678109809ef5d0ba69e0239434c52a9c5fd9289a2250ec
 
 in  packages


### PR DESCRIPTION
Right now fetching the `src/packages.dhall` takes a long time, but since at every release a small amount of groups change, adding hashes when importing them should make this much faster (because the users will have it cached already)