### PR TITLE
Update dotenv to v0.4.0

### DIFF
--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -11,5 +11,5 @@ in  { dotenv =
         , "spec"
         ]
         "https://github.com/nsaunders/purescript-dotenv.git"
-        "v0.3.0"
+        "v0.4.0"
     }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/nsaunders/purescript-dotenv/releases/tag/v0.4.0