### PR TITLE
Update dotenv to v0.4.1 [dependencies added]

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -615,10 +615,12 @@
       "parsing",
       "prelude",
       "psci-support",
-      "spec"
+      "run",
+      "spec",
+      "sunde"
     ],
     "repo": "https://github.com/nsaunders/purescript-dotenv.git",
-    "version": "v0.3.0"
+    "version": "v0.4.1"
   },
   "effect": {
     "dependencies": [

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -8,8 +8,10 @@ in  { dotenv =
         , "parsing"
         , "prelude"
         , "psci-support"
+        , "run"
         , "spec"
+        , "sunde"
         ]
         "https://github.com/nsaunders/purescript-dotenv.git"
-        "v0.3.0"
+        "v0.4.1"
     }

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -44,7 +44,7 @@ let packages =
       ⫽ ./groups/mschristiansen.dhall sha256:780ebeb7efa84796edcb45f03b589c7611d55be07ecf37a1c86e5faefbb12ad8
       ⫽ ./groups/natefaubion.dhall sha256:da088db0591ca741b5b89959269aec1c8d1cc5ee4a520cfaf9953a5aa5f44eae
       ⫽ ./groups/nkly.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
-      ⫽ ./groups/nsaunders.dhall sha256:4c6267557912d5410ba2b4fe4df6b311c5f3d85bd6b16b92308f190418f69f4b
+      ⫽ ./groups/nsaunders.dhall sha256:5f1f2a306f2135dc9d987e4997dbdd1f9fe9900132b179fc077c8b61c4125f85
       ⫽ ./groups/nwolverson.dhall sha256:2e955121b2839361edb787d554c6ea731e2b39bc354202a3933da5ffbce93a87
       ⫽ ./groups/oreshinya.dhall sha256:de9a180811060a9df03f209ec8a3a3d792ddc41bcba0c80b4a1d3d1977bcdb7b
       ⫽ ./groups/owickstrom.dhall sha256:4d4b5eec9e1ffd21ddfe45f65179c4ad6971953c58412af33c74322522275d76


### PR DESCRIPTION
I'm expecting CI to fail (see #377), but these are the correct changes for dotenv v0.4.1. #377 upgraded the dotenv version, but it did not include the new dependencies (run and sunde).