### PR TITLE
manually "unfreeze" packages.dhall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: format generate
 
 format:
 	@find src/ -iname "*.dhall" -exec dhall format --inplace {} \;
+	# we have to unfreeze packages.dhall manually
+	@sed 's/ sha256:.*//g' -i src/packages.dhall
 	@dhall freeze --all --inplace src/packages.dhall
 	@echo formatted dhall files
 


### PR DESCRIPTION
needed because Dhall does not update hashes, so you can very easily get
mismatches because of cache entries.