### PR TITLE
Added reactormonk/simple-timestamp

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2465,6 +2465,21 @@
     "repo": "https://github.com/oreshinya/purescript-simple-jwt.git",
     "version": "v1.0.2"
   },
+  "simple-timestamp": {
+    "dependencies": [
+      "console",
+      "datetime",
+      "effect",
+      "foreign",
+      "formatters",
+      "prelude",
+      "psci-support",
+      "simple-json",
+      "spec"
+    ],
+    "repo": "https://github.com/reactormonk/purescript-simple-timestamp.git",
+    "version": "v1.1.0"
+  },
   "sized-vectors": {
     "dependencies": [
       "arrays",

--- a/src/groups/reactormonk.dhall
+++ b/src/groups/reactormonk.dhall
@@ -13,4 +13,18 @@ in  { rave =
         ]
         "https://github.com/reactormonk/purescript-rave.git"
         "v0.1.1"
+    , simple-timestamp =
+        mkPackage
+        [ "console"
+        , "datetime"
+        , "effect"
+        , "foreign"
+        , "formatters"
+        , "prelude"
+        , "psci-support"
+        , "simple-json"
+        , "spec"
+        ]
+        "https://github.com/reactormonk/purescript-simple-timestamp.git"
+        "v1.1.0"
     }

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -53,7 +53,7 @@ let packages =
       ⫽ ./groups/passy.dhall sha256:f16b1b87991f2b03804e3a0f1f2812d79dbeeac593811a8c246a7025520c8cde
       ⫽ ./groups/purescript-freedom.dhall sha256:27320387a19e1c12f01960f121196cdde768cea01b364731e9316082ad7631bf
       ⫽ ./groups/purescript-spec.dhall sha256:0b666e1fbd314bf62d842fdbbf5e41e8c97aa68c7ba1f7e88a969fbe0f687b23
-      ⫽ ./groups/reactormonk.dhall sha256:3af16df4a4bc5ef5f076270532b4bf66ea647169557faf6f2e66fdb831578fa5
+      ⫽ ./groups/reactormonk.dhall sha256:013d323f30d6e77a77d290887fa79d71c3cf67f1ab5e6a5b2c12f4ad9b02e632
       ⫽ ./groups/rightfold.dhall sha256:fcc425bd0f37a7272341743ba23de1fa9afe69ba2fb03325ef1262c6fdb60f51
       ⫽ ./groups/rnons.dhall sha256:0d1f8201ce7094435c2695074c963c9e7e80a2b49839b6748515eda89da66d88
       ⫽ ./groups/sharkdp.dhall sha256:62ec96b8e487d45047cba0c26bf428b503a16fd76f62c041bc567ed9322ddb73


### PR DESCRIPTION
`make setup` fails with

```
formatted dhall files


↳ ./src/packages.dhall
  ↳ ./src/groups/purescript.dhall sha256:ae3da6b86c781a904f448ee6d48c377b30a7c7c28ae963b41eeda0539ac3f2cb
Cannot decode the version from this decoded CBOR expression: TList [TInt 8,TMap [(TString "arrays",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "nonempty"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "st"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"],TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-arrays.git"]),(TString "version",TList [TInt 18,TString "v5.3.0"])]]),(TString "assert",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "console"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-assert.git"]),(TString "version",TList [TInt 18,TString "v4.1.0"])]]),(TString "bifunctors",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-bifunctors.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "catenable-lists",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-catenable-lists.git"]),(TString "version",TList [TInt 18,TString "v5.0.1"])]]),(TString "console",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "effect"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-console.git"]),(TString "version",TList [TInt 18,TString "v4.2.0"])]]),(TString "const",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "contravariant"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-const.git"]),(TString "version",TList [TInt 18,TString "v4.1.0"])]]),(TString "contravariant",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "either"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-contravariant.git"]),(TString "version",TList [TInt 18,TString "v4.0.1"])]]),(TString "control",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-control.git"]),(TString "version",TList [TInt 18,TString "v4.1.0"])]]),(TString "datetime",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "either"],TList [TInt 18,TString "enums"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "functions"],TList [TInt 18,TString "gen"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "math"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "ordered-collections"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-datetime.git"]),(TString "version",TList [TInt 18,TString "v4.1.1"])]]),(TString "distributive",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "identity"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-distributive.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "effect",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-effect.git"]),(TString "version",TList [TInt 18,TString "v2.0.1"])]]),(TString "either",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-either.git"]),(TString "version",TList [TInt 18,TString "v4.1.1"])]]),(TString "enums",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "either"],TList [TInt 18,TString "gen"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "nonempty"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-enums.git"]),(TString "version",TList [TInt 18,TString "v4.0.1"])]]),(TString "exceptions",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "effect"],TList [TInt 18,TString "either"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-exceptions.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "exists",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-exists.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "foldable-traversable",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "orders"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-foldable-traversable.git"]),(TString "version",TList [TInt 18,TString "v4.1.1"])]]),(TString "foreign",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "either"],TList [TInt 18,TString "functions"],TList [TInt 18,TString "identity"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "strings"],TList [TInt 18,TString "transformers"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-foreign.git"]),(TString "version",TList [TInt 18,TString "v5.0.0"])]]),(TString "foreign-object",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "arrays"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "functions"],TList [TInt 18,TString "gen"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "st"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "typelevel-prelude"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-foreign-object.git"]),(TString "version",TList [TInt 18,TString "v2.0.3"])]]),(TString "free",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "catenable-lists"],TList [TInt 18,TString "control"],TList [TInt 18,TString "distributive"],TList [TInt 18,TString "either"],TList [TInt 18,TString "exists"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "lazy"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "transformers"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-free.git"]),(TString "version",TList [TInt 18,TString "v5.2.0"])]]),(TString "functions",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-functions.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "functors",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "const"],TList [TInt 18,TString "control"],TList [TInt 18,TString "either"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-functors.git"]),(TString "version",TList [TInt 18,TString "v3.1.1"])]]),(TString "gen",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "either"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "identity"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "nonempty"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-gen.git"]),(TString "version",TList [TInt 18,TString "v2.1.1"])]]),(TString "generics-rep",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "enums"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-generics-rep.git"]),(TString "version",TList [TInt 18,TString "v6.1.1"])]]),(TString "globals",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TString "Text"]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-globals.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "identity",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-identity.git"]),(TString "version",TList [TInt 18,TString "v4.1.0"])]]),(TString "integers",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "globals"],TList [TInt 18,TString "math"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-integers.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "invariant",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-invariant.git"]),(TString "version",TList [TInt 18,TString "v4.1.0"])]]),(TString "lazy",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-lazy.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "lcg",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "effect"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "math"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "random"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-lcg.git"]),(TString "version",TList [TInt 18,TString "v2.0.0"])]]),(TString "lists",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "lazy"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "nonempty"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-lists.git"]),(TString "version",TList [TInt 18,TString "v5.4.1"])]]),(TString "math",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TString "Text"]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-math.git"]),(TString "version",TList [TInt 18,TString "v2.1.1"])]]),(TString "maybe",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-maybe.git"]),(TString "version",TList [TInt 18,TString "v4.0.1"])]]),(TString "minibench",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "console"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "globals"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "math"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "refs"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-minibench.git"]),(TString "version",TList [TInt 18,TString "v2.0.0"])]]),(TString "newtype",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-newtype.git"]),(TString "version",TList [TInt 18,TString "v3.0.0"])]]),(TString "nonempty",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-nonempty.git"]),(TString "version",TList [TInt 18,TString "v5.0.0"])]]),(TString "ordered-collections",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "arrays"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "gen"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "st"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"],TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-ordered-collections.git"]),(TString "version",TList [TInt 18,TString "v1.6.1"])]]),(TString "orders",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-orders.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "parallel",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "either"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "functors"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "refs"],TList [TInt 18,TString "transformers"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-parallel.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "partial",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TString "Text"]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-partial.git"]),(TString "version",TList [TInt 18,TString "v2.0.1"])]]),(TString "prelude",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TString "Text"]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-prelude.git"]),(TString "version",TList [TInt 18,TString "v4.1.1"])]]),(TString "profunctor",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "contravariant"],TList [TInt 18,TString "control"],TList [TInt 18,TString "distributive"],TList [TInt 18,TString "either"],TList [TInt 18,TString "exists"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-profunctor.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "proxy",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-proxy.git"]),(TString "version",TList [TInt 18,TString "v3.0.0"])]]),(TString "psci-support",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "console"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-psci-support.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "quickcheck",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "arrays"],TList [TInt 18,TString "console"],TList [TInt 18,TString "control"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "either"],TList [TInt 18,TString "enums"],TList [TInt 18,TString "exceptions"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "gen"],TList [TInt 18,TString "generics-rep"],TList [TInt 18,TString "identity"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "lazy"],TList [TInt 18,TString "lcg"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "math"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "nonempty"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "record"],TList [TInt 18,TString "st"],TList [TInt 18,TString "strings"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "transformers"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-quickcheck.git"]),(TString "version",TList [TInt 18,TString "v6.1.0"])]]),(TString "random",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "effect"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "math"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-random.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "record",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "functions"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "st"],TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-record.git"]),(TString "version",TList [TInt 18,TString "v2.0.1"])]]),(TString "refs",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "effect"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-refs.git"]),(TString "version",TList [TInt 18,TString "v4.1.0"])]]),(TString "semirings",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "lists"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-semirings.git"]),(TString "version",TList [TInt 18,TString "v5.0.0"])]]),(TString "st",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tailrec"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-st.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "strings",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "arrays"],TList [TInt 18,TString "control"],TList [TInt 18,TString "either"],TList [TInt 18,TString "enums"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "gen"],TList [TInt 18,TString "integers"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "nonempty"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"],TList [TInt 18,TString "unsafe-coerce"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-strings.git"]),(TString "version",TList [TInt 18,TString "v4.0.1"])]]),(TString "tailrec",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "either"],TList [TInt 18,TString "identity"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "refs"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-tailrec.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "transformers",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "control"],TList [TInt 18,TString "distributive"],TList [TInt 18,TString "effect"],TList [TInt 18,TString "either"],TList [TInt 18,TString "exceptions"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "identity"],TList [TInt 18,TString "lazy"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tailrec"],TList [TInt 18,TString "tuples"],TList [TInt 18,TString "unfoldable"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-transformers.git"]),(TString "version",TList [TInt 18,TString "v4.2.0"])]]),(TString "tuples",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "distributive"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "invariant"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "type-equality"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-tuples.git"]),(TString "version",TList [TInt 18,TString "v5.1.0"])]]),(TString "type-equality",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TString "Text"]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-type-equality.git"]),(TString "version",TList [TInt 18,TString "v3.0.0"])]]),(TString "typelevel-prelude",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "prelude"],TList [TInt 18,TString "proxy"],TList [TInt 18,TString "type-equality"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-typelevel-prelude.git"]),(TString "version",TList [TInt 18,TString "v5.0.0"])]]),(TString "unfoldable",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "maybe"],TList [TInt 18,TString "partial"],TList [TInt 18,TString "prelude"],TList [TInt 18,TString "tuples"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-unfoldable.git"]),(TString "version",TList [TInt 18,TString "v4.0.2"])]]),(TString "unsafe-coerce",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TString "Text"]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-unsafe-coerce.git"]),(TString "version",TList [TInt 18,TString "v4.0.0"])]]),(TString "validation",TList [TInt 8,TMap [(TString "dependencies",TList [TInt 4,TNull,TList [TInt 18,TString "bifunctors"],TList [TInt 18,TString "control"],TList [TInt 18,TString "either"],TList [TInt 18,TString "foldable-traversable"],TList [TInt 18,TString "newtype"],TList [TInt 18,TString "prelude"]]),(TString "repo",TList [TInt 18,TString "https://github.com/purescript/purescript-validation.git"]),(TString "version",TList [TInt 18,TString "v4.2.0"])]])]]
```