### PR TITLE
Update freedom to v1.1.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -929,7 +929,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom.git",
-    "version": "v1.1.1"
+    "version": "v1.1.2"
   },
   "freedom-portal": {
     "dependencies": [

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -11,7 +11,7 @@ in  { freedom =
         , "web-html"
         ]
         "https://github.com/purescript-freedom/purescript-freedom.git"
-        "v1.1.1"
+        "v1.1.2"
     , freedom-portal =
         mkPackage
         [ "freedom" ]

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -51,7 +51,7 @@ let packages =
       ⫽ ./groups/paf31.dhall sha256:c258150860880b194f7e933135e8705c503a3de61c3ca55706c035aaa7e13b76
       ⫽ ./groups/paluh.dhall sha256:851aaf6de67056b5ff1c01e5c7c4eaa260e9384d217c5ef573c11eff1e18398b
       ⫽ ./groups/passy.dhall sha256:f16b1b87991f2b03804e3a0f1f2812d79dbeeac593811a8c246a7025520c8cde
-      ⫽ ./groups/purescript-freedom.dhall sha256:7c15a9310c6d08136531f6973fac958fb9046aad3992f639fc037777acee2c44
+      ⫽ ./groups/purescript-freedom.dhall sha256:2d9855641c1e57862f5daeb544a3c7d108938cee4131b8cf10d33729a664d48d
       ⫽ ./groups/purescript-spec.dhall sha256:0b666e1fbd314bf62d842fdbbf5e41e8c97aa68c7ba1f7e88a969fbe0f687b23
       ⫽ ./groups/reactormonk.dhall sha256:3af16df4a4bc5ef5f076270532b4bf66ea647169557faf6f2e66fdb831578fa5
       ⫽ ./groups/rightfold.dhall sha256:fcc425bd0f37a7272341743ba23de1fa9afe69ba2fb03325ef1262c6fdb60f51


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-freedom/purescript-freedom/releases/tag/v1.1.2