### PR TITLE
Update numbers to v7.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1759,7 +1759,7 @@
       "maybe"
     ],
     "repo": "https://github.com/sharkdp/purescript-numbers.git",
-    "version": "v6.0.0"
+    "version": "v7.0.0"
   },
   "options": {
     "dependencies": [

--- a/src/groups/sharkdp.dhall
+++ b/src/groups/sharkdp.dhall
@@ -9,7 +9,7 @@ in  { colors =
         mkPackage
         [ "globals", "math", "maybe" ]
         "https://github.com/sharkdp/purescript-numbers.git"
-        "v6.0.0"
+        "v7.0.0"
     , bigints =
         mkPackage
         [ "integers", "maybe", "strings" ]

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -56,7 +56,7 @@ let packages =
       ⫽ ./groups/reactormonk.dhall sha256:013d323f30d6e77a77d290887fa79d71c3cf67f1ab5e6a5b2c12f4ad9b02e632
       ⫽ ./groups/rightfold.dhall sha256:fcc425bd0f37a7272341743ba23de1fa9afe69ba2fb03325ef1262c6fdb60f51
       ⫽ ./groups/rnons.dhall sha256:0d1f8201ce7094435c2695074c963c9e7e80a2b49839b6748515eda89da66d88
-      ⫽ ./groups/sharkdp.dhall sha256:62ec96b8e487d45047cba0c26bf428b503a16fd76f62c041bc567ed9322ddb73
+      ⫽ ./groups/sharkdp.dhall sha256:d6d3b005e7200bc32348ddbf4e3751a12386f52b77c882702d44c65801c8f63b
       ⫽ ./groups/slamdata.dhall sha256:3f9efe8f0cda22338d8a60bd4d857f715147df9811c78d38ca7c63504a40101f
       ⫽ ./groups/spacchetti.dhall sha256:35ad2e7037e6516e3fb5a36fe4f4c3ab29a3cc20e0b2f240ccf5b5365e76e7f3
       ⫽ ./groups/spicydonuts.dhall sha256:a2392619c0b6b2e2b3ccb808c5487afb4918b8769887f67b629e83be5475c6e1


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/sharkdp/purescript-numbers/releases/tag/v7.0.0