### PR TITLE
Update bucketchain-simple-api to v0.5.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -343,7 +343,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git",
-    "version": "v0.4.2"
+    "version": "v0.5.0"
   },
   "bucketchain-sslify": {
     "dependencies": [

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -54,7 +54,7 @@ in  { bucketchain =
         mkPackage
         [ "bucketchain", "media-types", "simple-json" ]
         "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git"
-        "v0.4.2"
+        "v0.5.0"
     , bucketchain-sslify =
         mkPackage
         [ "bucketchain" ]

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -16,7 +16,7 @@ let packages =
       ⫽ ./groups/anttih.dhall sha256:fd1730256d9ffe106e6899ffa7e9a7fcc77571949fce5d9e3f363f3f114be45c
       ⫽ ./groups/bodil.dhall sha256:a60df1b1d43c8d2aa82fb9c98d88316ce8db6170bb65073bb86ef39d841881d9
       ⫽ ./groups/brandonhamilton.dhall sha256:2dfc0ba893d8c01cbdfa963f35d5fa8b1523929011c67aa4da26c8eda512f609
-      ⫽ ./groups/bucketchain.dhall sha256:c6c96eb5122c61248fca62a29fce7fd4bea5095b315865a5ae8e557868cf4bfe
+      ⫽ ./groups/bucketchain.dhall sha256:7fdee2174129598b8c54175b18c38793283f6adea6462ec5d61553b469cb7b26
       ⫽ ./groups/cdepillabout.dhall sha256:29d6005a2aa236b917865eecc9f166699f328672f18a789cdab3bf9146b2b9d4
       ⫽ ./groups/citizennet.dhall sha256:a3fb313db0ec4f461a56f0e8cd491911d70633ddade82e695c4f14bb2e165f05
       ⫽ ./groups/cprussin.dhall sha256:476c1e32520ad4ee640453c7b7476857a59b23693f76a28eb72523426f20b2dd


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Bucketchain/purescript-bucketchain-simple-api/releases/tag/v0.5.0