### PR TITLE
Update dotenv to v1.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -621,7 +621,7 @@
       "sunde"
     ],
     "repo": "https://github.com/nsaunders/purescript-dotenv.git",
-    "version": "v0.4.1"
+    "version": "v1.0.0"
   },
   "effect": {
     "dependencies": [

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -13,5 +13,5 @@ in  { dotenv =
         , "sunde"
         ]
         "https://github.com/nsaunders/purescript-dotenv.git"
-        "v0.4.1"
+        "v1.0.0"
     }

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -44,7 +44,7 @@ let packages =
       ⫽ ./groups/mschristiansen.dhall sha256:780ebeb7efa84796edcb45f03b589c7611d55be07ecf37a1c86e5faefbb12ad8
       ⫽ ./groups/natefaubion.dhall sha256:da088db0591ca741b5b89959269aec1c8d1cc5ee4a520cfaf9953a5aa5f44eae
       ⫽ ./groups/nkly.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
-      ⫽ ./groups/nsaunders.dhall sha256:5f1f2a306f2135dc9d987e4997dbdd1f9fe9900132b179fc077c8b61c4125f85
+      ⫽ ./groups/nsaunders.dhall sha256:3b7c8d4cc95a0336d5f8cc5fd2d2e963a1f3a580922aac94b172d3834d4a4463
       ⫽ ./groups/nwolverson.dhall sha256:2e955121b2839361edb787d554c6ea731e2b39bc354202a3933da5ffbce93a87
       ⫽ ./groups/oreshinya.dhall sha256:de9a180811060a9df03f209ec8a3a3d792ddc41bcba0c80b4a1d3d1977bcdb7b
       ⫽ ./groups/owickstrom.dhall sha256:7ca83086dba07b31780b61e0126ad934dff49d5596a992b1f457fa31e6379213


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/nsaunders/purescript-dotenv/releases/tag/v1.0.0