### PR TITLE
Update simple-timestamp to v1.3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2535,7 +2535,7 @@
       "spec"
     ],
     "repo": "https://github.com/reactormonk/purescript-simple-timestamp.git",
-    "version": "v1.1.0"
+    "version": "v1.3.0"
   },
   "sized-vectors": {
     "dependencies": [

--- a/src/groups/reactormonk.dhall
+++ b/src/groups/reactormonk.dhall
@@ -29,6 +29,6 @@
     , repo =
         "https://github.com/reactormonk/purescript-simple-timestamp.git"
     , version =
-        "v1.1.0"
+        "v1.3.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/reactormonk/purescript-simple-timestamp/releases/tag/v1.3.0