### PR TITLE
Update node-fs to v5.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1622,7 +1622,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript-node/purescript-node-fs.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "node-fs-aff": {
     "dependencies": [

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -47,7 +47,7 @@
     , repo =
         "https://github.com/purescript-node/purescript-node-fs.git"
     , version =
-        "v5.0.0"
+        "v5.0.1"
     }
 , node-fs-aff =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-node/purescript-node-fs/releases/tag/v5.0.1