### PR TITLE
Update node-http to v5.0.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1656,7 +1656,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript-node/purescript-node-http.git",
-    "version": "v5.0.1"
+    "version": "v5.0.2"
   },
   "node-net": {
     "dependencies": [

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -76,7 +76,7 @@
     , repo =
         "https://github.com/purescript-node/purescript-node-http.git"
     , version =
-        "v5.0.1"
+        "v5.0.2"
     }
 , node-net =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-node/purescript-node-http/releases/tag/v5.0.2