### PR TITLE
Update node-streams to v4.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1741,7 +1741,7 @@
       "prelude"
     ],
     "repo": "https://github.com/purescript-node/purescript-node-streams.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "node-telegram-bot-api": {
     "dependencies": [

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -140,7 +140,7 @@
     , repo =
         "https://github.com/purescript-node/purescript-node-streams.git"
     , version =
-        "v4.0.0"
+        "v4.0.1"
     }
 , node-url =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-node/purescript-node-streams/releases/tag/v4.0.1