### PR TITLE
Update basic-auth to v1.0.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -222,7 +222,7 @@
       "node-http"
     ],
     "repo": "https://github.com/oreshinya/purescript-basic-auth.git",
-    "version": "v1.0.1"
+    "version": "v1.0.2"
   },
   "behaviors": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -4,7 +4,7 @@
     , repo =
         "https://github.com/oreshinya/purescript-basic-auth.git"
     , version =
-        "v1.0.1"
+        "v1.0.2"
     }
 , crypto =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-basic-auth/releases/tag/v1.0.2