### PR TITLE
Update crypto to v2.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -523,7 +523,7 @@
       "node-buffer"
     ],
     "repo": "https://github.com/oreshinya/purescript-crypto.git",
-    "version": "v2.0.0"
+    "version": "v2.0.1"
   },
   "css": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -12,7 +12,7 @@
     , repo =
         "https://github.com/oreshinya/purescript-crypto.git"
     , version =
-        "v2.0.0"
+        "v2.0.1"
     }
 , identy =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-crypto/releases/tag/v2.0.1