### PR TITLE
Update hyper to v0.10.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1220,7 +1220,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/owickstrom/hyper.git",
-    "version": "v0.10.0"
+    "version": "v0.10.1"
   },
   "hypertrout": {
     "dependencies": [

--- a/src/groups/owickstrom.dhall
+++ b/src/groups/owickstrom.dhall
@@ -28,7 +28,7 @@
     , repo =
         "https://github.com/owickstrom/hyper.git"
     , version =
-        "v0.10.0"
+        "v0.10.1"
     }
 , hypertrout =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/owickstrom/purescript-hyper/releases/tag/v0.10.1