### PR TITLE
Update milkis to v7.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1488,7 +1488,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-milkis.git",
-    "version": "v7.0.1"
+    "version": "v7.1.0"
   },
   "minibench": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -89,7 +89,7 @@
     , repo =
         "https://github.com/justinwoo/purescript-milkis.git"
     , version =
-        "v7.0.1"
+        "v7.1.0"
     }
 , motsunabe =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-milkis/releases/tag/v7.1.0