### PR TITLE
Update simple-jwt to v1.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2530,7 +2530,7 @@
       "strings"
     ],
     "repo": "https://github.com/oreshinya/purescript-simple-jwt.git",
-    "version": "v1.0.3"
+    "version": "v1.1.0"
   },
   "simple-timestamp": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -52,6 +52,6 @@
     , repo =
         "https://github.com/oreshinya/purescript-simple-jwt.git"
     , version =
-        "v1.0.3"
+        "v1.1.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-simple-jwt/releases/tag/v1.1.0