### PR TITLE
Update routing-duplex to v0.4.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2384,7 +2384,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/natefaubion/purescript-routing-duplex.git",
-    "version": "v0.3.0"
+    "version": "v0.4.0"
   },
   "run": {
     "dependencies": [

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -55,7 +55,7 @@
     , repo =
         "https://github.com/natefaubion/purescript-routing-duplex.git"
     , version =
-        "v0.3.0"
+        "v0.4.0"
     }
 , run =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/natefaubion/purescript-routing-duplex/releases/tag/v0.4.0