### PR TITLE
Update group to v4.1.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1076,7 +1076,7 @@
       "lists"
     ],
     "repo": "https://github.com/morganthomas/purescript-group.git",
-    "version": "v4.0.0"
+    "version": "v4.1.1"
   },
   "halogen": {
     "dependencies": [

--- a/src/groups/morganthomas.dhall
+++ b/src/groups/morganthomas.dhall
@@ -4,6 +4,6 @@
     , repo =
         "https://github.com/morganthomas/purescript-group.git"
     , version =
-        "v4.0.0"
+        "v4.1.1"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/morganthomas/purescript-group/releases/tag/v4.1.1