### PR TITLE
Update halogen to v5.0.0-rc.6

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1102,7 +1102,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen.git",
-    "version": "v5.0.0-rc.5"
+    "version": "v5.0.0-rc.6"
   },
   "halogen-bootstrap": {
     "dependencies": [

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -131,7 +131,7 @@
     , repo =
         "https://github.com/slamdata/purescript-halogen.git"
     , version =
-        "v5.0.0-rc.5"
+        "v5.0.0-rc.6"
     }
 , halogen-bootstrap =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/slamdata/purescript-halogen/releases/tag/v5.0.0-rc.6