### PR TITLE
Update react-basic to v11.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2242,7 +2242,7 @@
       "web-html"
     ],
     "repo": "https://github.com/lumihq/purescript-react-basic.git",
-    "version": "v9.0.1"
+    "version": "v11.0.0"
   },
   "react-basic-hooks": {
     "dependencies": [

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -15,6 +15,6 @@
     , repo =
         "https://github.com/lumihq/purescript-react-basic.git"
     , version =
-        "v9.0.1"
+        "v11.0.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/lumihq/purescript-react-basic/releases/tag/v11.0.0