### PR TITLE
Update checked-exceptions to v3.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -411,7 +411,7 @@
       "variant"
     ],
     "repo": "https://github.com/natefaubion/purescript-checked-exceptions.git",
-    "version": "v3.0.0"
+    "version": "v3.1.0"
   },
   "cheerio": {
     "dependencies": [

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -4,7 +4,7 @@
     , repo =
         "https://github.com/natefaubion/purescript-checked-exceptions.git"
     , version =
-        "v3.0.0"
+        "v3.1.0"
     }
 , heterogeneous =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/natefaubion/purescript-checked-exceptions/releases/tag/v3.1.0