### PR TITLE
Add rev and sha256 fields to packages

### DIFF
--- a/src/groups/ad-si.dhall
+++ b/src/groups/ad-si.dhall
@@ -5,5 +5,9 @@
         "https://github.com/ad-si/purescript-result.git"
     , version =
         "v1.0.3"
+    , rev =
+        "a09ebc3749e3b902f8144fa4a22c95840ce46701"
+    , sha256 =
+        "18s19kp8n659fx36q46qrn2imks43mqs3k7y96cxwdl60smj74pk"
     }
 }

--- a/src/groups/ajnsit.dhall
+++ b/src/groups/ajnsit.dhall
@@ -17,5 +17,9 @@
         "https://github.com/ajnsit/purescript-concur.git"
     , version =
         "v0.3.8"
+    , rev =
+        "f06ff02d3e519db6ceecf4e75a99adca10104695"
+    , sha256 =
+        "0d8idglmz5wsg14rpmmpc54wk6hjfw219mmyjm9fgds5d0p2dhkb"
     }
 }

--- a/src/groups/alexadewit.dhall
+++ b/src/groups/alexadewit.dhall
@@ -11,5 +11,9 @@
         "https://github.com/AlexaDeWit/purescript-text-encoding.git"
     , version =
         "v0.0.9"
+    , rev =
+        "46d809d5806ed9bb725192a7a0cf0d679911aa39"
+    , sha256 =
+        "0zb4cs2wcn2lcfc80gghanclbxy9rgz836dgqs4finj3yg872p47"
     }
 }

--- a/src/groups/anttih.dhall
+++ b/src/groups/anttih.dhall
@@ -5,5 +5,9 @@
         "https://github.com/anttih/purescript-rationals.git"
     , version =
         "v5.0.0"
+    , rev =
+        "8c52d8cc891d1223150a31416220aa9b99404442"
+    , sha256 =
+        "1idvjvvx5kwmi8kj2ps95bcvlsgij1xgin4jfw3rmcqd930wqq6q"
     }
 }

--- a/src/groups/athanclark.dhall
+++ b/src/groups/athanclark.dhall
@@ -5,5 +5,9 @@
         "https://github.com/athanclark/purescript-float32.git"
     , version =
         "v0.1.1"
+    , rev =
+        "1ca78fedb0b2da65b9ec0969d16c0bb7155e4f29"
+    , sha256 =
+        "0g0yi4h9bdc1v8l7my2x19xqas5hbbkkhbj6z4r76559c9rbyvfr"
     }
 }

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -5,6 +5,10 @@
         "https://github.com/bodil/purescript-signal.git"
     , version =
         "v10.1.0"
+    , rev =
+        "58e44e7f8c20e9d057bcaffbd231893935548bb5"
+    , sha256 =
+        "03jkc6l01vv28drg1rjx9ymc2bndx9933ckf60bi4ar909kx64v5"
     }
 , sized-vectors =
     { dependencies =
@@ -20,6 +24,10 @@
         "https://github.com/bodil/purescript-sized-vectors.git"
     , version =
         "v3.1.0"
+    , rev =
+        "ddb8c8e21a2c37e611a9d031ffbb68b261380851"
+    , sha256 =
+        "1dldwalx2smij4mhhh63qf45ylj1sji029ayppinc3py035shblw"
     }
 , smolder =
     { dependencies =
@@ -36,6 +44,10 @@
         "https://github.com/bodil/purescript-smolder.git"
     , version =
         "v12.0.0"
+    , rev =
+        "1ac78c3ba802baf1e7cb235aebc14434c66fbe01"
+    , sha256 =
+        "1v8707hgm9g4k30afc30cxzfcz627bmxf7cn9wk3l3mh9ppl8kwd"
     }
 , test-unit =
     { dependencies =
@@ -54,6 +66,10 @@
         "https://github.com/bodil/purescript-test-unit.git"
     , version =
         "v15.0.0"
+    , rev =
+        "351c55b632e0c0ebffae05837909995a03de3406"
+    , sha256 =
+        "06lb90vppa7naqqwz7wbvlkkyz86pbdd3ycw3d2iygvxbzkz8xjn"
     }
 , typelevel =
     { dependencies =
@@ -62,5 +78,9 @@
         "https://github.com/bodil/purescript-typelevel.git"
     , version =
         "v5.0.0"
+    , rev =
+        "5ce2e704fd86f66ccb40a81366146811a1e1fb16"
+    , sha256 =
+        "1s0fdffmn386hahv670fc5vvj0x0cqk64i4jj95rfavffch4x7va"
     }
 }

--- a/src/groups/brandonhamilton.dhall
+++ b/src/groups/brandonhamilton.dhall
@@ -5,5 +5,9 @@
         "https://github.com/brandonhamilton/purescript-phoenix.git"
     , version =
         "v4.0.0"
+    , rev =
+        "93d24c8b93e8ff1008bf3a2da429e36d1216d51b"
+    , sha256 =
+        "1v054b511vig4r2m4z6g53bagfwx523s9p662fq09jhwbf94v4ip"
     }
 }

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -5,6 +5,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain.git"
     , version =
         "v0.3.0"
+    , rev =
+        "76b440a4f72ec50fea074098657c7392be5d23f9"
+    , sha256 =
+        "0qmqc5rbck0m9yv15mqrz3yqbapd66cxp5xbpjfsb9cyar8bkpm9"
     }
 , bucketchain-basic-auth =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-basic-auth.git"
     , version =
         "v0.2.0"
+    , rev =
+        "146dad06ba0b7042c275f25df4db56918a10aac9"
+    , sha256 =
+        "0wc2bax820wpcp6rjjchyrgy6740jypa54yg4wnv0iwhwwfg1sws"
     }
 , bucketchain-conditional =
     { dependencies =
@@ -21,6 +29,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-conditional.git"
     , version =
         "v0.2.0"
+    , rev =
+        "2a3e4e125f49d68c1641f3ec0022d3e908695c96"
+    , sha256 =
+        "0djvk4a1m5k7rvi8hkhmhxd552a26jc0h22w0sh3p9i0vxsnmv40"
     }
 , bucketchain-cors =
     { dependencies =
@@ -29,6 +41,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-cors.git"
     , version =
         "v0.2.0"
+    , rev =
+        "646fd548935a6158af8ee6d1cea0c2cb0e71c64d"
+    , sha256 =
+        "1kbji9x7ijqnjfcklygmgxwl53pm8kipifgnf7abcs0ra3x4pg83"
     }
 , bucketchain-csrf =
     { dependencies =
@@ -37,6 +53,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-csrf.git"
     , version =
         "v0.1.0"
+    , rev =
+        "702d62c35e0fa5d498982a869e98e036009450d4"
+    , sha256 =
+        "0czvbwy6w5n9h2vkwjwbgfl260kk5ibpiy8ssflzdf16m14v2440"
     }
 , bucketchain-header-utils =
     { dependencies =
@@ -45,6 +65,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-header-utils.git"
     , version =
         "v0.1.0"
+    , rev =
+        "6690b3bddafea290530d331a6061a1633a11b029"
+    , sha256 =
+        "1vgzpfrw7m32sp1pskx1m11js0yx7sxx0dl7g1lk6aji7byp7adb"
     }
 , bucketchain-health =
     { dependencies =
@@ -53,6 +77,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-health.git"
     , version =
         "v0.2.0"
+    , rev =
+        "1022ee6cec55f49f624b904c824254cbc426cae8"
+    , sha256 =
+        "1cils1kyhc81z3dpf0v5ykhhb4lxygj6rr3mja0w7qfj07qv0xm8"
     }
 , bucketchain-history-api-fallback =
     { dependencies =
@@ -61,6 +89,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-history-api-fallback.git"
     , version =
         "v0.2.0"
+    , rev =
+        "8ced83b5e524523682229ebb063e29de19da7849"
+    , sha256 =
+        "16dpk0wj69b725z8466i14wy0g80qwlk80anzivxsflqybjdswhv"
     }
 , bucketchain-logger =
     { dependencies =
@@ -69,6 +101,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-logger.git"
     , version =
         "v0.3.0"
+    , rev =
+        "e0d612384747eaeb630751ff33c0afcd9ded79f8"
+    , sha256 =
+        "15i043yvwr0qinvvmi05xbi6ixpqjkj7z6x4zms881iihra4g8qa"
     }
 , bucketchain-secure =
     { dependencies =
@@ -77,6 +113,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-secure.git"
     , version =
         "v0.1.0"
+    , rev =
+        "d51f484c5162b2b37c129efca6b5cba01ea68565"
+    , sha256 =
+        "1c9vh4j91xscwq7ms4r2cygd4dp5vkjb8lrjmp79c8navx1myzrh"
     }
 , bucketchain-simple-api =
     { dependencies =
@@ -85,6 +125,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git"
     , version =
         "v0.5.0"
+    , rev =
+        "1955c1995731d49dfd722bca9f3f8b5e593e8a2e"
+    , sha256 =
+        "1fmzz64p4jzd00ipig0qr7mqanmri49r9mspj0i8y02ihqjd2zcj"
     }
 , bucketchain-sslify =
     { dependencies =
@@ -93,6 +137,10 @@
         "https://github.com/Bucketchain/purescript-bucketchain-sslify.git"
     , version =
         "v0.2.0"
+    , rev =
+        "4bb3dfdf8ea444ab43b4b81a7a48ecca509a778f"
+    , sha256 =
+        "145dnylf976q9hz00xybvhdssanw6r9804sxz4mcsh7m4i0xznq1"
     }
 , bucketchain-static =
     { dependencies =
@@ -101,5 +149,9 @@
         "https://github.com/Bucketchain/purescript-bucketchain-static.git"
     , version =
         "v0.3.0"
+    , rev =
+        "0c8b21f957e6c8dd66c789cebf2ab92b1b26dc2d"
+    , sha256 =
+        "1p5px861pih2hran7fddgrr062z2q0vfxvjvdis32gdk0qq1ggmb"
     }
 }

--- a/src/groups/cdepillabout.dhall
+++ b/src/groups/cdepillabout.dhall
@@ -5,5 +5,9 @@
         "https://github.com/cdepillabout/purescript-email-validate.git"
     , version =
         "v5.0.0"
+    , rev =
+        "b73471c0f479b6a5ad6fb903d3388013a9b79810"
+    , sha256 =
+        "1c7zsc6zskpidps3w2rcaad25zr2kfyd41aznnwrhisdhd0b86fx"
     }
 }

--- a/src/groups/citizennet.dhall
+++ b/src/groups/citizennet.dhall
@@ -15,5 +15,9 @@
         "https://github.com/citizennet/purescript-fuzzy.git"
     , version =
         "v0.2.1"
+    , rev =
+        "3c63d2a61b582f795644c3e2697746a87f96427a"
+    , sha256 =
+        "1sn46sqkc3ygxsn003b4q1ff7x73315mpfhz9n0jj5nvbjd345ir"
     }
 }

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -35,6 +35,10 @@
         "https://github.com/cprussin/purescript-httpure.git"
     , version =
         "v0.8.3"
+    , rev =
+        "ae56c9f0a1fcd08cb677888b785b9dc8bdbb7d23"
+    , sha256 =
+        "0kcvyyrdpj6cm3r0gzfza0dxf0c0biga1hs9n750vs8r9z36wknp"
     }
 , monad-logger =
     { dependencies =
@@ -61,6 +65,10 @@
         "https://github.com/cprussin/purescript-monad-logger.git"
     , version =
         "v1.2.0"
+    , rev =
+        "c154835166d7966e92015b8a32a0f515bba4370e"
+    , sha256 =
+        "1nmasx112rx3f1dv9qmbrhf273zzx2z9abccmqpm7g3d8ng5p5xq"
     }
 , node-electron =
     { dependencies =
@@ -80,5 +88,9 @@
         "https://github.com/cprussin/purescript-node-electron.git"
     , version =
         "v0.0.2"
+    , rev =
+        "19734790aa42c7a09e0efd725dad3828f6246c46"
+    , sha256 =
+        "1vgvjs0fi4p6cfgp61cnh7vj2czmyvxdsdyr535jqs9x61r2zwwh"
     }
 }

--- a/src/groups/danieljharvey.dhall
+++ b/src/groups/danieljharvey.dhall
@@ -11,6 +11,10 @@
         "https://github.com/danieljharvey/purescript-refined.git"
     , version =
         "v0.2.0"
+    , rev =
+        "145e40a9f5d4131651020d2955a0490e6e040edf"
+    , sha256 =
+        "0fhpdka3q7r43iy49f1wqjmlg0q57gccd420m55ry220v5k2nd1h"
     }
 , radox =
     { dependencies =
@@ -19,6 +23,10 @@
         "https://github.com/danieljharvey/purescript-radox.git"
     , version =
         "v0.0.8"
+    , rev =
+        "67f2bbb24009b8b33d8e6620997f15894002bd59"
+    , sha256 =
+        "0bkignn6dnf31ixmbkizx6w4g97m782b7dmaqdhsgs97i71lm94f"
     }
 , react-radox =
     { dependencies =
@@ -27,6 +35,10 @@
         "https://github.com/danieljharvey/purescript-react-radox.git"
     , version =
         "v0.0.5"
+    , rev =
+        "8004820fa46f3078169638915174e77abdc7d38a"
+    , sha256 =
+        "1w0pv9rvx84hr5mjc37n0g1jf62p7w3i220ym2ziws8gvwinxsig"
     }
 , cssom =
     { dependencies =
@@ -35,6 +47,10 @@
         "https://github.com/danieljharvey/purescript-cssom.git"
     , version =
         "v0.0.2"
+    , rev =
+        "bd1fffc883f18cc6a79ce41e1e688b5a0f0351f7"
+    , sha256 =
+        "0nq1jzp6ljhqrfflbvm6yqfynlm0kcddmxygnw3vzbbq1x07gjxv"
     }
 , stylesheet =
     { dependencies =
@@ -51,6 +67,10 @@
         "https://github.com/danieljharvey/purescript-stylesheet.git"
     , version =
         "v0.0.3"
+    , rev =
+        "baa2d1abeba470a1ff35a429ea618d9d081c4252"
+    , sha256 =
+        "1dwga99r64gn1hc7jvcgplj8qc2rpqs2hk0f22ikkb2pvc7w02wq"
     }
 , react-stylesheet =
     { dependencies =
@@ -59,5 +79,9 @@
         "https://github.com/danieljharvey/purescript-react-stylesheet.git"
     , version =
         "v0.0.2"
+    , rev =
+        "f8079e5446a73fbc53ba3a8e841905029e1a0d37"
+    , sha256 =
+        "03d4sdp57pij2zl2h76iv92n0ipinamia1p7mj9ddx6d6jz6ch52"
     }
 }

--- a/src/groups/dwhitney.dhall
+++ b/src/groups/dwhitney.dhall
@@ -5,5 +5,9 @@
         "https://github.com/dwhitney/purescript-react-basic-native.git"
     , version =
         "v0.1.3"
+    , rev =
+        "f5a963df87ffa0cc8b2810cc5df78c724c9afcbe"
+    , sha256 =
+        "1n6dxn0740qpqq05wy5dq5d5my6kgsi1z0k5ribh48nbxaiv7g2f"
     }
 }

--- a/src/groups/epost.dhall
+++ b/src/groups/epost.dhall
@@ -16,5 +16,9 @@
         "https://github.com/epost/purescript-node-postgres.git"
     , version =
         "v5.0.0"
+    , rev =
+        "798526465af865381d8b4565c9766e89320a2fab"
+    , sha256 =
+        "1lcsm2n1vqiji6hgm2nwd4q12iwhbq5a6n4ab2sqyk79ndk2vd8i"
     }
 }

--- a/src/groups/ethul.dhall
+++ b/src/groups/ethul.dhall
@@ -5,6 +5,10 @@
         "https://github.com/ethul/purescript-freeap.git"
     , version =
         "v5.0.1"
+    , rev =
+        "8f7bebc36c267794c31d5af1a5737746645e59df"
+    , sha256 =
+        "007840vpxa4gz0fvjbahyky2xzz625gzfaiy2wjpb50d9qacsr7y"
     }
 , undefinable =
     { dependencies =
@@ -13,5 +17,9 @@
         "https://github.com/ethul/purescript-undefinable.git"
     , version =
         "v4.0.0"
+    , rev =
+        "9c5c863e638b93cf73e2cfde8dfbde91480ee011"
+    , sha256 =
+        "03z91g1n6zmiqgqqxi65g99a9qxfb8dcnzg2wnb16i2rl8frsl3v"
     }
 }

--- a/src/groups/f-o-a-m.dhall
+++ b/src/groups/f-o-a-m.dhall
@@ -17,5 +17,9 @@
         "https://github.com/f-o-a-m/purescript-optparse.git"
     , version =
         "v3.0.1"
+    , rev =
+        "14eb29f6d7c1ad455f39ace45f1c0dc53f1f7f4f"
+    , sha256 =
+        "01pqq0h9f91j275pd4ph53j49lddp6b4pwdwm78chfbyvjir7z2x"
     }
 }

--- a/src/groups/fehrenbach.dhall
+++ b/src/groups/fehrenbach.dhall
@@ -13,5 +13,9 @@
         "https://github.com/fehrenbach/purescript-unordered-collections.git"
     , version =
         "v1.8.2"
+    , rev =
+        "15bf60f1490ed15b81ff0436bcc3cc7f17a1eeef"
+    , sha256 =
+        "12ni0sqrp594zwrb6y0ckhdfpgci84z4cqaqkfib4d3zqpnizvml"
     }
 }

--- a/src/groups/felixmulder.dhall
+++ b/src/groups/felixmulder.dhall
@@ -5,5 +5,9 @@
         "https://github.com/felixmulder/purescript-json-schema.git"
     , version =
         "v0.0.1"
+    , rev =
+        "43a7e7fcb29ea80fabef128a55d166032baa959f"
+    , sha256 =
+        "09ha1q62lvr45nnck9mfidlwcwrsm0iwpgxdqnirfyc9lvv80m10"
     }
 }

--- a/src/groups/felixschl.dhall
+++ b/src/groups/felixschl.dhall
@@ -12,5 +12,9 @@
         "https://github.com/felixSchl/purescript-pipes.git"
     , version =
         "v6.0.0"
+    , rev =
+        "a9533035f6fe8e59a65c6d11a3a7c767f3c9ae67"
+    , sha256 =
+        "0vl37f42dy4w4hswiay22w0n14k7sr670x54iwn7428larzrzs8y"
     }
 }

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -5,6 +5,10 @@
         "https://github.com/garyb/purescript-debug.git"
     , version =
         "v4.0.0"
+    , rev =
+        "b1484b8aac685dc83c1d938d71407495ae2a2259"
+    , sha256 =
+        "0gwjj80akys0h111i74n429fmny992gx0r4rk1n98gqlqm5cmi21"
     }
 , indexed-monad =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/garyb/purescript-indexed-monad.git"
     , version =
         "v1.0.0"
+    , rev =
+        "2e16035a1dec57d3b4bb741cef7603fc98f63775"
+    , sha256 =
+        "04m83vpbba52mwpsfn247bp5mlwaji08a78n8mhp87dzx1jbir90"
     }
 , quickcheck-laws =
     { dependencies =
@@ -21,5 +29,9 @@
         "https://github.com/garyb/purescript-quickcheck-laws.git"
     , version =
         "v5.0.1"
+    , rev =
+        "7f0160093340033f594dfb264422ac615cfac15e"
+    , sha256 =
+        "1cdrxb2wc80f35a46irndn5ymgyxkdkv3ppgrrk84kx3ksvc5hbf"
     }
 }

--- a/src/groups/gcanti.dhall
+++ b/src/groups/gcanti.dhall
@@ -5,5 +5,9 @@
         "https://github.com/gcanti/purescript-prettier.git"
     , version =
         "v0.2.0"
+    , rev =
+        "f79667f01f25ddc2e10b5fc8e7d18348f34f6fca"
+    , sha256 =
+        "17fkkdiiwd4ydqg606ragawxlf8kkl9nnizpsciginzw85jzpy5s"
     }
 }

--- a/src/groups/hdgarrood.dhall
+++ b/src/groups/hdgarrood.dhall
@@ -5,5 +5,9 @@
         "https://github.com/hdgarrood/purescript-ansi.git"
     , version =
         "v5.0.0"
+    , rev =
+        "e060b4a7c9a0df9359871cb0c5773139e5525d2f"
+    , sha256 =
+        "16kgy9zbdms9appd69gad2bka44ijkcnc9p0kf5g7x672jypx3ar"
     }
 }

--- a/src/groups/i-am-tom.dhall
+++ b/src/groups/i-am-tom.dhall
@@ -13,5 +13,9 @@
         "https://github.com/i-am-tom/purescript-data-algebrae.git"
     , version =
         "v4.0.0"
+    , rev =
+        "0085f81647b7a84f79d75e13428ce4eed35cc9be"
+    , sha256 =
+        "0shjjfi7rr1snkvss1m9snm9hmb482sg1930f7r2j5vy5dzpw3bl"
     }
 }

--- a/src/groups/icyrockcom.dhall
+++ b/src/groups/icyrockcom.dhall
@@ -5,5 +5,9 @@
         "https://github.com/icyrockcom/purescript-cheerio.git"
     , version =
         "v0.2.0"
+    , rev =
+        "70e11f60f554d8747e566c32f7f0c0bdec5f76bc"
+    , sha256 =
+        "0d6lqxbj3l997ky8ymfd97msgnwjn9i4w66iqrgzkx4rw4fpdjwi"
     }
 }

--- a/src/groups/jacereda.dhall
+++ b/src/groups/jacereda.dhall
@@ -15,5 +15,9 @@
         "https://github.com/jacereda/purescript-arraybuffer.git"
     , version =
         "v10.0.0"
+    , rev =
+        "5d1a7fd386d374fbc6041aeb9ac78b6d50b23455"
+    , sha256 =
+        "011qz76yljdppqnlwpzc5416ra04wiy4m22a1kaylr0ghjk23ljn"
     }
 }

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -5,6 +5,10 @@
         "https://github.com/justinwoo/purescript-chirashi.git"
     , version =
         "v1.0.0"
+    , rev =
+        "3589e247a0f269b0f7552828876b965eaa2fcafd"
+    , sha256 =
+        "1wjh6lxg36fws4qm4myfw6xsy2p1vj3sb03iin10dyaz48j88ldz"
     }
 , choco-pie =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/justinwoo/purescript-chocopie.git"
     , version =
         "v5.0.0"
+    , rev =
+        "c842beb9468e8cedb17f7a31b3e8166be05b0856"
+    , sha256 =
+        "1q3xilbk8chsy3c07jal9j8nmcvmydk0kvdv9nrbffpxqc02n457"
     }
 , expect-inferred =
     { dependencies =
@@ -21,6 +29,10 @@
         "https://github.com/justinwoo/purescript-expect-inferred.git"
     , version =
         "v2.0.0"
+    , rev =
+        "68d560ed30919cb0146a1136e3826c9b4c8264a4"
+    , sha256 =
+        "0vb36hl2znvrhzs4jvcd7nvzk3wcpzalbxxpc0fl13m5ibbq9dah"
     }
 , format-nix =
     { dependencies =
@@ -29,6 +41,10 @@
         "https://github.com/justinwoo/format-nix.git"
     , version =
         "v0.3.0"
+    , rev =
+        "ca32a16deee11127b620470e63a1370d77a48975"
+    , sha256 =
+        "0s4q1lfm3sjcyrqcz28kpms23phi9h6sirkr8lgglsli33pfs5y9"
     }
 , gomtang-basic =
     { dependencies =
@@ -37,6 +53,10 @@
         "https://github.com/justinwoo/purescript-gomtang-basic.git"
     , version =
         "v0.2.0"
+    , rev =
+        "8c47355f29b85a6a64c61f90190d525dcc9221d9"
+    , sha256 =
+        "11zp6id0hrq9hmr0w395ldf403p6v6ldz0miisrxmdmpcrcm3j54"
     }
 , jajanmen =
     { dependencies =
@@ -45,6 +65,10 @@
         "https://github.com/justinwoo/purescript-jajanmen.git"
     , version =
         "v1.0.0"
+    , rev =
+        "91c2ed5a54fd539d8d94f741a2027b774d0816a7"
+    , sha256 =
+        "0qzim7arpdz0byvg3s4bj1ybrf1svi1z5x9kpai2a7l5y6adg8hz"
     }
 , kancho =
     { dependencies =
@@ -53,6 +77,10 @@
         "https://github.com/justinwoo/purescript-kancho.git"
     , version =
         "v2.0.0"
+    , rev =
+        "81df453734ea516a63940b4964810f01531d18b4"
+    , sha256 =
+        "0ylf15vy7xmdag77nzcgv1y768fvcx8sw8j69rzkb4dnfrrmms1h"
     }
 , kishimen =
     { dependencies =
@@ -61,6 +89,10 @@
         "https://github.com/justinwoo/purescript-kishimen.git"
     , version =
         "v1.0.1"
+    , rev =
+        "8a9b11f9bcdaf4ff63c2e572def3d0b2a4e2c870"
+    , sha256 =
+        "153d0mlf2x7xvbql5w0s4jl56s51aq0bg8ldxd3fm2kj7m0bay22"
     }
 , lenient-html-parser =
     { dependencies =
@@ -69,6 +101,10 @@
         "https://github.com/justinwoo/purescript-lenient-html-parser.git"
     , version =
         "v4.0.0"
+    , rev =
+        "9e249aa16279d6a63de0d87ef0b624203e9a7f7c"
+    , sha256 =
+        "19i4vcj93nz400yiyl4rj190alp5yv9lxm4vw83a5nrk32pll5xi"
     }
 , makkori =
     { dependencies =
@@ -77,6 +113,10 @@
         "https://github.com/justinwoo/purescript-makkori.git"
     , version =
         "v1.0.0"
+    , rev =
+        "bdd0e3899075b86e860b310fd69353ac80a85a98"
+    , sha256 =
+        "09i5j2xqp6rjmljc6kbn3h1ybw1j3dfwdl6bxzr0wqk3y14wpdlq"
     }
 , milkis =
     { dependencies =
@@ -90,6 +130,10 @@
         "https://github.com/justinwoo/purescript-milkis.git"
     , version =
         "v7.2.0"
+    , rev =
+        "6a55398de664595406e0b5fe7cd3646a4501f1ed"
+    , sha256 =
+        "1i6l8k4clrnq4wxbdzzq08kagk591yr24xip86z1j7xap98y02xg"
     }
 , motsunabe =
     { dependencies =
@@ -98,6 +142,10 @@
         "https://github.com/justinwoo/purescript-motsunabe.git"
     , version =
         "v2.0.0"
+    , rev =
+        "d016e6319fef40119abba726e31d066e7c211875"
+    , sha256 =
+        "03r81xs0gw5nchm93ap2lpirkng8bzgsb8xc5jxlii4sw8wn8ndh"
     }
 , naporitan =
     { dependencies =
@@ -106,6 +154,10 @@
         "https://github.com/justinwoo/purescript-naporitan.git"
     , version =
         "v1.0.0"
+    , rev =
+        "e911d10260897f5dec7caa034604691c7146f7ff"
+    , sha256 =
+        "0d7krc91cda623ajarnwp5s1d35x4nr18y3095rz97yxw00lajzj"
     }
 , node-he =
     { dependencies =
@@ -114,6 +166,10 @@
         "https://github.com/justinwoo/purescript-node-he.git"
     , version =
         "v0.2.0"
+    , rev =
+        "d2e3b78863c163e62713ef776059b92a5a91d8f5"
+    , sha256 =
+        "00ha94m5ysv1r5lqfh90rnada9xp4jnncxqf4id1iskxhhkg3h28"
     }
 , node-sqlite3 =
     { dependencies =
@@ -122,6 +178,10 @@
         "https://github.com/justinwoo/purescript-node-sqlite3.git"
     , version =
         "v6.0.0"
+    , rev =
+        "84f1b4333800edf5db2477a5aec4f93aa5f301f0"
+    , sha256 =
+        "0xrby3w76i7ig26jgfvr8lmiih0rkj2d3rbzm5d7x476444n7l56"
     }
 , node-telegram-bot-api =
     { dependencies =
@@ -130,6 +190,10 @@
         "https://github.com/justinwoo/purescript-node-telegram-bot-api.git"
     , version =
         "v4.0.0"
+    , rev =
+        "eaa1302f5daada0307c47993370d05239dc6f7c6"
+    , sha256 =
+        "17srhm44210phyhd5ik936h9c8igz105g9mrfzi1qax6xcadkdgk"
     }
 , record-extra =
     { dependencies =
@@ -138,6 +202,10 @@
         "https://github.com/justinwoo/purescript-record-extra.git"
     , version =
         "v3.0.0"
+    , rev =
+        "41a837de4168b60790c53d9cb18bc7fb6961bb17"
+    , sha256 =
+        "1zhsgafd02h7161xldnf4z3sfjacp2if8py157igiszkjxaipvdd"
     }
 , redux-devtools =
     { dependencies =
@@ -146,6 +214,10 @@
         "https://github.com/justinwoo/purescript-redux-devtools.git"
     , version =
         "v0.1.0"
+    , rev =
+        "e9fae256f444c5a3d63c54bdc99e0623c4f07208"
+    , sha256 =
+        "1bsi8b0gzxk4s2qm1mlasgmkwkz6f0bggwy7rxwnpfklid8yxdxm"
     }
 , shoronpo =
     { dependencies =
@@ -154,6 +226,10 @@
         "https://github.com/justinwoo/purescript-shoronpo.git"
     , version =
         "v0.3.0"
+    , rev =
+        "6427a2f64816ad005b152e11ef467ba513a18e22"
+    , sha256 =
+        "0vyzs7yzc8dxvci2y6qzbwa82ag8big5qwiffx73fzvk52k5hfy6"
     }
 , sijidou =
     { dependencies =
@@ -162,6 +238,10 @@
         "https://github.com/justinwoo/purescript-sijidou.git"
     , version =
         "v1.0.0"
+    , rev =
+        "1535631b8659c40450f9d48de49f2420ff30c27d"
+    , sha256 =
+        "0i56nxkjks8lgav1m1m3b40l615kdsq45x8dwznqsqn269ks0xjl"
     }
 , simple-json =
     { dependencies =
@@ -180,6 +260,10 @@
         "https://github.com/justinwoo/purescript-simple-json.git"
     , version =
         "v7.0.0"
+    , rev =
+        "d6c4163f6ad65be97b148ebf86c900cb821da5a8"
+    , sha256 =
+        "1x2f4zq1m9r3vg9hdpjld98jd56w7fss8fzvlrmnrw6xzd1gi456"
     }
 , simple-json-generics =
     { dependencies =
@@ -188,6 +272,10 @@
         "https://github.com/justinwoo/purescript-simple-json-generics.git"
     , version =
         "v0.1.0"
+    , rev =
+        "f7127b94bd2da73b28e863c299edb72a42ee4bce"
+    , sha256 =
+        "1izbrh9614yi0lzpnqbn9q7hbllhvvhrgyziganj7rzgphwn3ywx"
     }
 , simple-json-utils =
     { dependencies =
@@ -196,6 +284,10 @@
         "https://github.com/justinwoo/purescript-simple-json-utils.git"
     , version =
         "v0.1.0"
+    , rev =
+        "ec5df413e1058959454e380de42f590046a43373"
+    , sha256 =
+        "05mpvn3hrl86sapns88h7k9ccv29d8xmcnll8iz6ix5ibmh9vk2v"
     }
 , sunde =
     { dependencies =
@@ -204,6 +296,10 @@
         "https://github.com/justinwoo/purescript-sunde.git"
     , version =
         "v2.0.0"
+    , rev =
+        "e9c898ac0ffd5e61d82a6c02606ab84241278709"
+    , sha256 =
+        "051kfqc06fbhavd3anvfhi5wfj76a6q4piis4lplypaw9g4n64l2"
     }
 , toppokki =
     { dependencies =
@@ -218,6 +314,10 @@
         "https://github.com/justinwoo/purescript-toppokki.git"
     , version =
         "v1.1.0"
+    , rev =
+        "392636bcb8900399f7751f01dcb1edf71458b49e"
+    , sha256 =
+        "1lydm0ixxi5pihg4d0yll5xli2j7rb5lj2y49dinq8hnvh9yv728"
     }
 , tortellini =
     { dependencies =
@@ -237,6 +337,10 @@
         "https://github.com/justinwoo/purescript-tortellini.git"
     , version =
         "v5.1.0"
+    , rev =
+        "1ef407cb5e241209fb6207c48f4790d9bf38eaa3"
+    , sha256 =
+        "00difmyxp5374gqfxf46zyjpphi87lx5ylwfjd8m8idap901gzh7"
     }
 , type-isequal =
     { dependencies =
@@ -245,6 +349,10 @@
         "https://github.com/justinwoo/purescript-type-isequal.git"
     , version =
         "v0.1.0"
+    , rev =
+        "f54e8071e75b979b1f711c354fd7c8a690273f25"
+    , sha256 =
+        "0bsz9d160kpih35xdbd617x48c394spdmk1dj9v6mhsii87hwa54"
     }
 , xiaomian =
     { dependencies =
@@ -253,5 +361,9 @@
         "https://github.com/justinwoo/purescript-xiaomian.git"
     , version =
         "v0.1.0"
+    , rev =
+        "811264fd65cad9fa958ad3d0a5cff59450193b2a"
+    , sha256 =
+        "1n2ghz1z04xqxmjqdh0phnslq6fc7027j70si0lbp7njic6xljjp"
     }
 }

--- a/src/groups/kcsongor.dhall
+++ b/src/groups/kcsongor.dhall
@@ -5,5 +5,9 @@
         "https://github.com/kcsongor/purescript-record-format.git"
     , version =
         "v2.0.0"
+    , rev =
+        "c277a20030b8c3d831b9ef8b50fc70b1edd26831"
+    , sha256 =
+        "13fngd0aw3hhpw4b911a3wyk974jdlhhr5myrkwh6blgrhxqq6wx"
     }
 }

--- a/src/groups/klntsky.dhall
+++ b/src/groups/klntsky.dhall
@@ -15,6 +15,10 @@
         "https://github.com/klntsky/purescript-array-views.git"
     , version =
         "v0.0.2"
+    , rev =
+        "3882708f782eed8979435ec4b159f04e5fcd1c63"
+    , sha256 =
+        "0fzxcl4sjyx8vc2dq9cbmg9b2n04w9pns7p2b67z9hg44pj7f14b"
     }
 , search-trie =
     { dependencies =
@@ -29,5 +33,9 @@
         "https://github.com/klntsky/purescript-search-trie.git"
     , version =
         "v1.0.0"
+    , rev =
+        "028405e35e7b6cf085c4b68a86fa5364bb6775d0"
+    , sha256 =
+        "0z8i0n0jyx07jvjz1b4a6gjg76a4l3ba3cj1w1bizgijc3rz99r2"
     }
 }

--- a/src/groups/krisajenkins.dhall
+++ b/src/groups/krisajenkins.dhall
@@ -5,5 +5,9 @@
         "https://github.com/krisajenkins/purescript-remotedata.git"
     , version =
         "v4.2.0"
+    , rev =
+        "8dbd12110f6a338c36afd6c3208dd5fa031c0573"
+    , sha256 =
+        "15ab34s3bz2kbzrhbxixzwpxmgj356px8z1s77r2pa9fjnmkn40v"
     }
 }

--- a/src/groups/kritzcreek.dhall
+++ b/src/groups/kritzcreek.dhall
@@ -5,6 +5,10 @@
         "https://github.com/kritzcreek/purescript-matrices.git"
     , version =
         "v4.0.0"
+    , rev =
+        "7ddcd2d09f94757374ddab3c9879d459a023ee17"
+    , sha256 =
+        "1h2hgzz6k37q17f96i1sl26s0pgw4jwrs0ziczqvax4q3r27i0wg"
     }
 , psc-ide =
     { dependencies =
@@ -22,5 +26,9 @@
         "https://github.com/kRITZCREEK/purescript-psc-ide.git"
     , version =
         "v15.0.1"
+    , rev =
+        "0f5c433c57391ae68ce1b285a0964bd19fdae073"
+    , sha256 =
+        "05cdjf8n329xhsa0cnk0v8ani5ss70ma9s445z9ysfgmcmmfgfds"
     }
 }

--- a/src/groups/liamgoodacre.dhall
+++ b/src/groups/liamgoodacre.dhall
@@ -11,5 +11,9 @@
         "https://github.com/LiamGoodacre/purescript-filterable.git"
     , version =
         "v3.0.2"
+    , rev =
+        "b7bff31576261bc66bf29bfeca7679c2b107d68e"
+    , sha256 =
+        "0pn66mrgrpnlpd1lmywj5f0hbm9mnyjahqj276vz5v2xzlr0q63g"
     }
 }

--- a/src/groups/lukajcb.dhall
+++ b/src/groups/lukajcb.dhall
@@ -5,5 +5,9 @@
         "https://github.com/LukaJCB/purescript-snabbdom.git"
     , version =
         "v1.0.1"
+    , rev =
+        "fad4049c3cf70c466748d2d723def5c36f3e106c"
+    , sha256 =
+        "0khzsd4rsljs189hc64lw7da2sbwzgizlxfq0gq1rj7y99lhlvsd"
     }
 }

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -16,5 +16,9 @@
         "https://github.com/lumihq/purescript-react-basic.git"
     , version =
         "v11.0.0"
+    , rev =
+        "bb3cfcbde081f75f4f3e1d04f0a83655f09af437"
+    , sha256 =
+        "133kfzp78x6vd6v5b05ph9p08pj4mxiv28hrchv13hn0ndhhm6fx"
     }
 }

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -14,6 +14,10 @@
         "https://github.com/menelaos/purescript-b64.git"
     , version =
         "v0.0.5"
+    , rev =
+        "114d33a1cc4e78815e6725a76e63cf6d0c113577"
+    , sha256 =
+        "1rxspyslsyvqnv11i1yg6vrdjlvn0f2kynmm0h8443q3ig82m5r9"
     }
 , encoding =
     { dependencies =
@@ -22,6 +26,10 @@
         "https://github.com/menelaos/purescript-encoding.git"
     , version =
         "v0.0.5"
+    , rev =
+        "8a697897538ac8d0c7de66770bb83a98b0a662b9"
+    , sha256 =
+        "1p52293hmqv3j3lra2fgamk5mpkalwp925frsl25w16n6gkx71p6"
     }
 , stringutils =
     { dependencies =
@@ -37,5 +45,9 @@
         "https://github.com/menelaos/purescript-stringutils.git"
     , version =
         "v0.0.9"
+    , rev =
+        "7983cde4aa1edac2b31611eb7c1fd17abcff667c"
+    , sha256 =
+        "00c679d5lk37gbfby2kasyq45rla6a0shg64zhyd2r4xrj0a74r4"
     }
 }

--- a/src/groups/michaelxavier.dhall
+++ b/src/groups/michaelxavier.dhall
@@ -11,5 +11,9 @@
         "https://github.com/MichaelXavier/purescript-server-sent-events.git"
     , version =
         "v0.2.0"
+    , rev =
+        "9797621c151e0becb24580d97cf771b62df78259"
+    , sha256 =
+        "0n482cn7sydgiy3d4iw5bw7v9rvjqzkd36114l9ihlair8k130c6"
     }
 }

--- a/src/groups/morganthomas.dhall
+++ b/src/groups/morganthomas.dhall
@@ -5,5 +5,9 @@
         "https://github.com/morganthomas/purescript-group.git"
     , version =
         "v4.1.1"
+    , rev =
+        "8e1fcc20c636d3c67732f09c30b46f9e14ba8af4"
+    , sha256 =
+        "1f0bzfn6vb9vgsynas2sq5a0vf34avjd934jymv0pf3w6rid8h0w"
     }
 }

--- a/src/groups/mschristiansen.dhall
+++ b/src/groups/mschristiansen.dhall
@@ -5,5 +5,9 @@
         "https://github.com/mschristiansen/purescript-halogen-bootstrap4.git"
     , version =
         "v0.1.4"
+    , rev =
+        "1f3c45119b1679766dfcaf6402c0a52d313991ea"
+    , sha256 =
+        "0gaf7n9mgr927xbr6ssbld11z6y30imnp6bnwvfmw9hshfcfn6ki"
     }
 }

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -5,6 +5,10 @@
         "https://github.com/natefaubion/purescript-checked-exceptions.git"
     , version =
         "v3.1.0"
+    , rev =
+        "b73844cfb6e128afb521a3d5aa61410fbe9992dc"
+    , sha256 =
+        "1kfyihhsaz8g03vzvyir89adyzlcw4m95fr3xsmia8sd1vsb8646"
     }
 , heterogeneous =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/natefaubion/purescript-heterogeneous.git"
     , version =
         "v0.4.1"
+    , rev =
+        "854e6fe8e52c570954c22275aaf657ef068c73f8"
+    , sha256 =
+        "0kbp6k6nbqwyzf12lrgf1v18ln5rakmxzb8s2dha1lfnk1r2f92m"
     }
 , psa-utils =
     { dependencies =
@@ -37,6 +45,10 @@
         "https://github.com/natefaubion/purescript-psa-utils.git"
     , version =
         "v6.0.0"
+    , rev =
+        "3191b19ef0ca6863658e5f73cbf5baca7a9487fc"
+    , sha256 =
+        "10z910i9d99fw3aiknskn6psvrndab0vrfh8bbx7ix497vy1gymn"
     }
 , routing-duplex =
     { dependencies =
@@ -56,6 +68,10 @@
         "https://github.com/natefaubion/purescript-routing-duplex.git"
     , version =
         "v0.4.0"
+    , rev =
+        "a76379757707725bb73d30a64ed4973c8c347c4e"
+    , sha256 =
+        "098dzmxfv8pk9rk9ncjwd0cz4663wx057183mwrd443fhfyagl5q"
     }
 , run =
     { dependencies =
@@ -77,6 +93,10 @@
         "https://github.com/natefaubion/purescript-run.git"
     , version =
         "v3.0.1"
+    , rev =
+        "68eec5b5957e6f36fc4e206a1d4dd2adc3095587"
+    , sha256 =
+        "1lb95hxmmv3ndrxxwl1rwja8sply5na2bsgy1iym82cm96xcxib3"
     }
 , run-streaming =
     { dependencies =
@@ -85,6 +105,10 @@
         "https://github.com/natefaubion/purescript-run-streaming.git"
     , version =
         "v2.0.0"
+    , rev =
+        "ff42f0526db9e3b03f9729dcda64852e006c03d2"
+    , sha256 =
+        "0gpk81244512lw6kw0l3rjh0dd7ymr5808hy6q1gcdrz973cyc6g"
     }
 , spork =
     { dependencies =
@@ -111,6 +135,10 @@
         "https://github.com/natefaubion/purescript-spork"
     , version =
         "v1.0.0"
+    , rev =
+        "131f07d669f2c09175faed39c3445c6a46ca924f"
+    , sha256 =
+        "00qgap0jmnsgv0w9mkgbxjp2vnkfqly404l3igb75i8s0gp1fxp2"
     }
 , variant =
     { dependencies =
@@ -128,5 +156,9 @@
         "https://github.com/natefaubion/purescript-variant.git"
     , version =
         "v6.0.1"
+    , rev =
+        "31e620334124d2ca8b1e608c27d74b607a5831e9"
+    , sha256 =
+        "0cn227q57zbqm6r1aw5kvnp1x8zkc1x7wx28yyz311lmy7k1mkql"
     }
 }

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -14,5 +14,9 @@
         "https://github.com/nsaunders/purescript-dotenv.git"
     , version =
         "v1.0.0"
+    , rev =
+        "641fd4cdd48c30faea233c094f06e1b7ddb87c77"
+    , sha256 =
+        "0dpjymzxz9wh6kll8q5qmx761pkp64y95dyyr4mwmj07k3anch3i"
     }
 }

--- a/src/groups/nwolverson.dhall
+++ b/src/groups/nwolverson.dhall
@@ -5,6 +5,10 @@
         "https://github.com/nwolverson/purescript-aff-promise.git"
     , version =
         "v2.1.0"
+    , rev =
+        "033d6b90252e0390b0de7845e21de919bc4c3a0e"
+    , sha256 =
+        "0khm53lvxgvc7fbsvcr2h2wlhcgay8vq45755f0w8vpk1441dvww"
     }
 , suggest =
     { dependencies =
@@ -20,5 +24,9 @@
         "https://github.com/nwolverson/purescript-suggest.git"
     , version =
         "v5.0.0"
+    , rev =
+        "bdce2322ddc5deef1c226937580c10df7d1930c1"
+    , sha256 =
+        "15vl0i9rf2xfdc5rsdax7mxjraaq9qx41lrq805ws5p20yqh9b4d"
     }
 }

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -5,6 +5,10 @@
         "https://github.com/oreshinya/purescript-basic-auth.git"
     , version =
         "v1.0.2"
+    , rev =
+        "1a62ffdd2c9bf82f8225d168be70e417a1cf4c83"
+    , sha256 =
+        "14125zxbzshwwapm63vqb7bqs6l0z1j48z42ls7siw2pwkmbly7x"
     }
 , crypto =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/oreshinya/purescript-crypto.git"
     , version =
         "v2.0.1"
+    , rev =
+        "0acc404042b5effa63d5aee08ffcc1b3e1e0e5ce"
+    , sha256 =
+        "1cx2xjakgp3jlnqiqf9az3al0wbwazhf2zkzdngzx4lx60r9jxq9"
     }
 , identy =
     { dependencies =
@@ -21,6 +29,10 @@
         "https://github.com/oreshinya/purescript-identy.git"
     , version =
         "v2.0.2"
+    , rev =
+        "dd22f4b051aab0498a9c91752e003f07e81aa009"
+    , sha256 =
+        "159kaig2nyzkll6pl30vvvdy3x3prhy0fp1cpvji20lbg50q76j0"
     }
 , mysql =
     { dependencies =
@@ -29,6 +41,10 @@
         "https://github.com/oreshinya/purescript-mysql.git"
     , version =
         "v3.0.1"
+    , rev =
+        "806f74c688837e76ac36972525a99bca05e80874"
+    , sha256 =
+        "1x854jawqjc1z6fimlag5a2p01cqnj9pfahy5ixmgqydrqp54g98"
     }
 , nodemailer =
     { dependencies =
@@ -37,6 +53,10 @@
         "https://github.com/oreshinya/purescript-nodemailer.git"
     , version =
         "v2.0.2"
+    , rev =
+        "5883df3b8e90eeb90a7780ba17c82da6b36f8fa6"
+    , sha256 =
+        "1pf32zjghgppci9gyqv1wmq2f4hzqdykwij8yncn81bdqrz9v0sn"
     }
 , simple-emitter =
     { dependencies =
@@ -45,6 +65,10 @@
         "https://github.com/oreshinya/purescript-simple-emitter.git"
     , version =
         "v1.0.0"
+    , rev =
+        "b24c088297d981e480857184c67abb706aae2374"
+    , sha256 =
+        "0hy7pbw6qfczns0yvfjyiqkkl0fqj0nf7jcwyf1q5sdcn3xm3b0x"
     }
 , simple-jwt =
     { dependencies =
@@ -53,5 +77,9 @@
         "https://github.com/oreshinya/purescript-simple-jwt.git"
     , version =
         "v1.1.1"
+    , rev =
+        "860362ed001ac1f28108408e63f181a0f9bb735b"
+    , sha256 =
+        "10b2pnq6vl5cj6j3g2wjrdm10mk5kdaw4sckbgbs0fw5gdz8wf7d"
     }
 }

--- a/src/groups/owickstrom.dhall
+++ b/src/groups/owickstrom.dhall
@@ -29,6 +29,10 @@
         "https://github.com/owickstrom/hyper.git"
     , version =
         "v0.10.1"
+    , rev =
+        "cdc97dc9b82dfc61e6f144c138ea2dd0c4d1eee5"
+    , sha256 =
+        "04vspn2gaa0pk65y92fwmzmab7541plxw6b638npamvr5qwpsifi"
     }
 , hypertrout =
     { dependencies =
@@ -45,6 +49,10 @@
         "https://github.com/owickstrom/purescript-hypertrout.git"
     , version =
         "v0.11.0"
+    , rev =
+        "b1643fed848e317c10f86eae34ec96d9c6b87b1b"
+    , sha256 =
+        "09h521g9nf7zlvfvbzyy590vv0zzwh3cbwmdc5cdy2n8q6s20mx7"
     }
 , spec-discovery =
     { dependencies =
@@ -53,6 +61,10 @@
         "https://github.com/owickstrom/purescript-spec-discovery.git"
     , version =
         "v4.0.0"
+    , rev =
+        "b90ca588dc054c951201488d982765226a8393e9"
+    , sha256 =
+        "0kwc4nvy6rpbnhayang92h74fgyr28bh82pskwj7lm4sy513vhfw"
     }
 , spec-quickcheck =
     { dependencies =
@@ -61,6 +73,10 @@
         "https://github.com/owickstrom/purescript-spec-quickcheck.git"
     , version =
         "v3.1.0"
+    , rev =
+        "77a426996f7869f8424ed2720ab55c1f8d45bc84"
+    , sha256 =
+        "1l51v2j4z2cwdnf9hyx69jmlzlkk24l8gj38iphfspaiwyqwcmpg"
     }
 , trout =
     { dependencies =
@@ -76,6 +92,10 @@
         "https://github.com/owickstrom/purescript-trout.git"
     , version =
         "v0.12.0"
+    , rev =
+        "63c3af6bb5e10acb997c3671f58855d6970ce6ac"
+    , sha256 =
+        "1fyvhzzk7l40scig87fzf0syl68cp6p6ra436vbqkpfax1i31vpd"
     }
 , trout-client =
     { dependencies =
@@ -93,5 +113,9 @@
         "https://github.com/owickstrom/purescript-trout-client.git"
     , version =
         "v0.11.0"
+    , rev =
+        "cc933fafd21d1c9f3b1a524b9ed6b5aa225e7085"
+    , sha256 =
+        "0mx8i5q3xcdg99fsgbx1ikyx5k58sxfzjqpbygw3f6kzffcsl7hf"
     }
 }

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -14,6 +14,10 @@
         "https://github.com/paf31/purescript-behaviors.git"
     , version =
         "v7.0.0"
+    , rev =
+        "f55fd957500e9a70d21e1f20e95f8dc0696724ef"
+    , sha256 =
+        "1gy5pwk408pq8di89ql88qngazf93izkbrjx91vasfzbryvs2pg8"
     }
 , event =
     { dependencies =
@@ -30,6 +34,10 @@
         "https://github.com/paf31/purescript-event.git"
     , version =
         "v1.2.4"
+    , rev =
+        "af8b8d2e381f423c0b5e739e92668e392e77efce"
+    , sha256 =
+        "0zzlg4ggzv9s2ipg84wj4qbdib3qn38zdzpr8brv79kvb3f0lnzz"
     }
 , folds =
     { dependencies =
@@ -38,6 +46,10 @@
         "https://github.com/paf31/purescript-folds.git"
     , version =
         "v5.2.0"
+    , rev =
+        "996d88ac0d71df73f3a2e80eca80e41347fef01a"
+    , sha256 =
+        "0wlsx2xq65f7nlz21acm8b5sraxfbdqcdrnjms3m5mbpdsndyn5y"
     }
 , foreign-generic =
     { dependencies =
@@ -55,6 +67,10 @@
         "https://github.com/paf31/purescript-foreign-generic.git"
     , version =
         "v10.0.0"
+    , rev =
+        "46f09996bd54efc146bc1725783789dbac7d6a5b"
+    , sha256 =
+        "1assvgmnim908plv7wzz4mrvq3lh4ayimgz5xk5njyz8p6pzkyvl"
     }
 , leibniz =
     { dependencies =
@@ -63,6 +79,10 @@
         "https://github.com/paf31/purescript-leibniz.git"
     , version =
         "v5.0.0"
+    , rev =
+        "ed1fa97012a01126c499f2d0e28dfea2919296b3"
+    , sha256 =
+        "1xxc84jx9qd4z89mlhjw602l6350cilvw8kd67ixsmsnd0krnl3f"
     }
 , memoize =
     { dependencies =
@@ -79,6 +99,10 @@
         "https://github.com/paf31/purescript-memoize.git"
     , version =
         "v5.0.0"
+    , rev =
+        "7f116edf1a8418d55dd864964456fe2b51dbf0a5"
+    , sha256 =
+        "191dsdp2znx028y8jg2c7iz2zpj8xfgd0zvnb5bx2zqky934a4dv"
     }
 , pairing =
     { dependencies =
@@ -87,6 +111,10 @@
         "https://github.com/paf31/purescript-pairing.git"
     , version =
         "v5.1.0"
+    , rev =
+        "779ac384f911a1ddb5b713864b9236203046c20c"
+    , sha256 =
+        "1lh3lna84rrmqlcab2p012cjjndhi9wyx2f3lv3bgwfgj65r2nbx"
     }
 , safely =
     { dependencies =
@@ -95,6 +123,10 @@
         "https://github.com/paf31/purescript-safely.git"
     , version =
         "v4.0.0"
+    , rev =
+        "454fa86e47c6f65e28f8c4fda3615d409f350505"
+    , sha256 =
+        "0ifcgr0savmfyk140kc17rm6z41a4hjmppbgi7ahi2szzgfii29g"
     }
 , string-parsers =
     { dependencies =
@@ -113,6 +145,10 @@
         "https://github.com/paf31/purescript-string-parsers.git"
     , version =
         "v5.0.0"
+    , rev =
+        "ff023be7eeaf3dd129e652f9f1c225dfb196cf94"
+    , sha256 =
+        "1lykswyd3icv9lx4r096lxfd244i0pzj2f4fpm604czzlfw6bspv"
     }
 , yargs =
     { dependencies =
@@ -121,5 +157,9 @@
         "https://github.com/paf31/purescript-yargs.git"
     , version =
         "v4.0.0"
+    , rev =
+        "a517d190f15e7817a3144a982663281f125d28e8"
+    , sha256 =
+        "10xbiyghplg54n9p7vs7mba9gmqfsbyiz0045c5p4p3v6djj60w3"
     }
 }

--- a/src/groups/paluh.dhall
+++ b/src/groups/paluh.dhall
@@ -5,6 +5,10 @@
         "https://github.com/paluh/purescript-pointed-list.git"
     , version =
         "v0.4.0"
+    , rev =
+        "606de7f6ebd953aea822747c21fa4d73ef5187bc"
+    , sha256 =
+        "15mzg2812v4vnb27fdgkw0yc6qsn81yc3jg1jl7rxfjsdaa9z95r"
     }
 , polyform =
     { dependencies =
@@ -23,5 +27,9 @@
         "https://github.com/paluh/purescript-polyform.git"
     , version =
         "v0.8.0"
+    , rev =
+        "6c534095292f8f6c4c558d67b65a81fe30fb2304"
+    , sha256 =
+        "15mdrk772yg4azxc3f00wyyszif862l6i9x6csz0ia1dc845n9yy"
     }
 }

--- a/src/groups/passy.dhall
+++ b/src/groups/passy.dhall
@@ -5,5 +5,9 @@
         "https://github.com/passy/purescript-errors.git"
     , version =
         "v4.1.0"
+    , rev =
+        "30abf43a6e6b62552e18769c0b624c1d7ef10f7d"
+    , sha256 =
+        "09xph8rhd25l24az1bfyjkbrp0h7ymxm4b8kw180f8kn2qx6q99a"
     }
 }

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -5,6 +5,10 @@
         "https://github.com/purescript-contrib/purescript-aff-coroutines.git"
     , version =
         "v7.0.0"
+    , rev =
+        "f2f410f3cc9030487ddadf9ffdaab75ba508bde9"
+    , sha256 =
+        "1cbly4m2na5kf3halj68rjy5khydb71gzz0ry323z5h1i0fna2g9"
     }
 , argonaut =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/purescript-contrib/purescript-argonaut.git"
     , version =
         "v6.0.0"
+    , rev =
+        "3365736b862ec6d8948ea31debebd04d0abf12fc"
+    , sha256 =
+        "0b2jy5sf2lnn1r4kxnnm2vsr5iqkfas0jqp9yrrjmg7qngkd6qkw"
     }
 , argonaut-codecs =
     { dependencies =
@@ -29,6 +37,10 @@
         "https://github.com/purescript-contrib/purescript-argonaut-codecs.git"
     , version =
         "v6.0.2"
+    , rev =
+        "b0317d576e10aa73600c43f835bfad45679d0aff"
+    , sha256 =
+        "1i8dm95kbcl7k92jqnylhng1rjcqx5z12yhf6mwvp0z0bmsz250b"
     }
 , argonaut-core =
     { dependencies =
@@ -48,6 +60,10 @@
         "https://github.com/purescript-contrib/purescript-argonaut-core.git"
     , version =
         "v5.0.0"
+    , rev =
+        "bebd7099b9cd681659dcd93407e639219360188e"
+    , sha256 =
+        "1d3jgyap3vwc7mc01ji6brmd2n8lr9mmgx0fl88yalrm2j89jrcc"
     }
 , argonaut-generic =
     { dependencies =
@@ -56,6 +72,10 @@
         "https://github.com/purescript-contrib/purescript-argonaut-generic.git"
     , version =
         "v5.0.0"
+    , rev =
+        "fbaa763f8cc6771c66c6207bf9c00fa56cc44a57"
+    , sha256 =
+        "0lll7wkgf4xzsbaagxbcjpjh9y4vj0hfvcg94plsz3sda597a6nv"
     }
 , argonaut-traversals =
     { dependencies =
@@ -64,6 +84,10 @@
         "https://github.com/purescript-contrib/purescript-argonaut-traversals.git"
     , version =
         "v7.0.0"
+    , rev =
+        "6613254947961686341eaa1ed23886c9d2587d93"
+    , sha256 =
+        "0mr6c7c64c5b7ia0b68vsjyjxw06ac9908xpgxdd969kpvcwq9x3"
     }
 , arraybuffer-types =
     { dependencies =
@@ -72,6 +96,10 @@
         "https://github.com/purescript-contrib/purescript-arraybuffer-types.git"
     , version =
         "v2.0.0"
+    , rev =
+        "505aa3de50a1400e5f2fce4a8e7b1a39abaa8fd9"
+    , sha256 =
+        "059a8n49yhl46l1b1j2qj4ichzq6dzj29ajkfvw88npzj5w2rshy"
     }
 , coroutines =
     { dependencies =
@@ -80,6 +108,10 @@
         "https://github.com/purescript-contrib/purescript-coroutines.git"
     , version =
         "v5.0.0"
+    , rev =
+        "6f5750d1b200d6bb405f681f974887508b82b4d2"
+    , sha256 =
+        "1jax7by8kn9fjg00avhziy3n18i3510iwzs3d73ziplanbw4qw4k"
     }
 , form-urlencoded =
     { dependencies =
@@ -88,6 +120,10 @@
         "https://github.com/purescript-contrib/purescript-form-urlencoded.git"
     , version =
         "v4.0.1"
+    , rev =
+        "36df7951f69a62f7dcf545787734420f4a8bf83a"
+    , sha256 =
+        "14nb7mslmbms4wn4j6a7nrz8xmnach3qgcf8i1hgql1c8j7zkqz8"
     }
 , freet =
     { dependencies =
@@ -103,6 +139,10 @@
         "https://github.com/purescript-contrib/purescript-freet.git"
     , version =
         "v4.0.0"
+    , rev =
+        "8b9cee0a143ec965eaa6e2d9ccfd24fd1f129bd7"
+    , sha256 =
+        "1kpgggwimxjvdvhn6s7z4lzg3yw1rqg5f7pyamx9gh232s4va40i"
     }
 , http-methods =
     { dependencies =
@@ -111,6 +151,10 @@
         "https://github.com/purescript-contrib/purescript-http-methods.git"
     , version =
         "v4.0.2"
+    , rev =
+        "f3672edd166d323849b9dfd1e01c6eeb978fd56c"
+    , sha256 =
+        "1wfgrlnl33bcqw54hbc8icah2fi0rvi5zxhz07665vy9p5ppvkqs"
     }
 , js-date =
     { dependencies =
@@ -119,6 +163,10 @@
         "https://github.com/purescript-contrib/purescript-js-date.git"
     , version =
         "v6.0.0"
+    , rev =
+        "f332c15f14322434ddd1945ca2db8040294447bf"
+    , sha256 =
+        "19qyzbr4a1ca8znbd8gcbz0a801f5p1v238ky3408gdx4ba32zjd"
     }
 , js-timers =
     { dependencies =
@@ -127,6 +175,10 @@
         "https://github.com/purescript-contrib/purescript-js-timers.git"
     , version =
         "v4.0.1"
+    , rev =
+        "8206d3d8034357b4665828e52f7ff1b8cb46611e"
+    , sha256 =
+        "1a8092sli7zqw1wflibhjza1ww21dxl7x7r602iazzwh2g70v4dg"
     }
 , jquery =
     { dependencies =
@@ -135,6 +187,10 @@
         "https://github.com/purescript-contrib/purescript-jquery.git"
     , version =
         "v5.0.0"
+    , rev =
+        "cb46882fc478fa01e9189561a146d3e9526e2a4c"
+    , sha256 =
+        "0nbsjggnd4hy0pd7sr0slm4mvdqvzvn47lrg8vwhcq29nb3l7w7v"
     }
 , machines =
     { dependencies =
@@ -152,6 +208,10 @@
         "https://github.com/purescript-contrib/purescript-machines.git"
     , version =
         "v5.1.0"
+    , rev =
+        "a600c024ce9a2a391898cc2195f1e144ef72e22f"
+    , sha256 =
+        "0yhbhnsdf0cnvwr199ydhfh7n6z1sanyspscnfzqqavz4zj0isxc"
     }
 , media-types =
     { dependencies =
@@ -160,6 +220,10 @@
         "https://github.com/purescript-contrib/purescript-media-types.git"
     , version =
         "v4.0.1"
+    , rev =
+        "e304498356539547b4ed9a7f79513a847c907962"
+    , sha256 =
+        "0ykwmxrhmwfy6c5mxjxa43xdf5xqakrqyvr5fn986yad50gjqj75"
     }
 , now =
     { dependencies =
@@ -168,6 +232,10 @@
         "https://github.com/purescript-contrib/purescript-now.git"
     , version =
         "v4.0.0"
+    , rev =
+        "090feddf7c7dec2a812eca090cd211e87ccad606"
+    , sha256 =
+        "18h5pif2dy4r7w1xg2zw4mvdqlar9xqp3rawkiavmsc946ncf3zs"
     }
 , nullable =
     { dependencies =
@@ -176,6 +244,10 @@
         "https://github.com/purescript-contrib/purescript-nullable.git"
     , version =
         "v4.1.1"
+    , rev =
+        "8d413f02224b8281bfa8037e45fbbf9fe2e254fd"
+    , sha256 =
+        "14qaxxga8gqlr4pijyvqycdyhjr6qpz3h4aarficw5j75b7x8nyv"
     }
 , options =
     { dependencies =
@@ -184,6 +256,10 @@
         "https://github.com/purescript-contrib/purescript-options.git"
     , version =
         "v5.0.0"
+    , rev =
+        "bc0109fb1a18d5f51aa32914618e96d1ec9d8cf5"
+    , sha256 =
+        "1n25pp0xsxfdxsnfdjjwlxz79iam9kapx4al9aj24yi148xhqckl"
     }
 , parsing =
     { dependencies =
@@ -202,6 +278,10 @@
         "https://github.com/purescript-contrib/purescript-parsing.git"
     , version =
         "v5.0.3"
+    , rev =
+        "e801a0ef42f3211b1602a94a269eef7ce551423f"
+    , sha256 =
+        "0m5xvb5kis28laj3navyyakyq408vw115c2dvngf1vljzh1hk5kj"
     }
 , profunctor-lenses =
     { dependencies =
@@ -230,6 +310,10 @@
         "https://github.com/purescript-contrib/purescript-profunctor-lenses.git"
     , version =
         "v6.2.0"
+    , rev =
+        "a058930ab7c73f5c4676a0cc91ea1a7433300c17"
+    , sha256 =
+        "0bb8ib00in8d65kvympdlfncb7bp1qqsjvvpw9zfwiwf67ix4v57"
     }
 , react =
     { dependencies =
@@ -245,6 +329,10 @@
         "https://github.com/purescript-contrib/purescript-react.git"
     , version =
         "v7.0.1"
+    , rev =
+        "a2e40f93f0dd47a6e185462431799e0e0c6e8667"
+    , sha256 =
+        "0kym675db8i4wzd0rh1f17k4mcfbf4pwnhpf7zhzkm9zaj7wc2cg"
     }
 , react-dom =
     { dependencies =
@@ -253,6 +341,10 @@
         "https://github.com/purescript-contrib/purescript-react-dom.git"
     , version =
         "v6.1.0"
+    , rev =
+        "441e1705ab8fc5fb382d9b3b3516f40ef7234e6c"
+    , sha256 =
+        "19kzsahx3kvgbi9bhnnz50fjmqvvgslsg6rk028bj4v28m8gra40"
     }
 , strongcheck =
     { dependencies =
@@ -288,6 +380,10 @@
         "https://github.com/purescript-contrib/purescript-strongcheck.git"
     , version =
         "v4.1.1"
+    , rev =
+        "6e681e66882c8bd6d7f99cc5cbcaf6fe0d3e6ee8"
+    , sha256 =
+        "0c30w9y6mabphjiizk69hv43ahb1x8rg960nz4mccxb8hnj26z9x"
     }
 , these =
     { dependencies =
@@ -296,6 +392,10 @@
         "https://github.com/purescript-contrib/purescript-these.git"
     , version =
         "v4.0.0"
+    , rev =
+        "fc19af52b34f8f128f9981aa27aab4becd7a79d5"
+    , sha256 =
+        "0ywwpbcz1d0pdi3f9h9kla52vq1if8zwdz7jq7lqz5s8zj8kyg5r"
     }
 , unicode =
     { dependencies =
@@ -304,6 +404,10 @@
         "https://github.com/purescript-contrib/purescript-unicode.git"
     , version =
         "v4.0.1"
+    , rev =
+        "bb70f5a17aa9bcad05104c5a3f191fd75bb3d2ce"
+    , sha256 =
+        "1a53jv7pzyjk5v6kmwwy50d3l8d26k0id59sn8g3lzkih24nalhp"
     }
 , unsafe-reference =
     { dependencies =
@@ -312,5 +416,9 @@
         "https://github.com/purescript-contrib/purescript-unsafe-reference"
     , version =
         "v3.0.1"
+    , rev =
+        "79d7de7b9351346a73e6c060d80532c95ba1c7c1"
+    , sha256 =
+        "0q758dz59qz0li4s3w1qcg921xp5i5rh6i1l611iv7rr8cbj11al"
     }
 }

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -12,6 +12,10 @@
         "https://github.com/purescript-freedom/purescript-freedom.git"
     , version =
         "v1.1.2"
+    , rev =
+        "7ff7a2f310995ec03e66dc97a1bf7583bcc8dd62"
+    , sha256 =
+        "0cfhr53ngx67wimb69zs2lbj3qrzngpbbg5i679i2ab73y867h82"
     }
 , freedom-portal =
     { dependencies =
@@ -20,6 +24,10 @@
         "https://github.com/purescript-freedom/purescript-freedom-portal.git"
     , version =
         "v1.0.0"
+    , rev =
+        "8ab5580739d0098d494dc1170b3d162144fd141d"
+    , sha256 =
+        "0l72rlzc3jna90ly36zillhglfh1p2mispdvnwjzrd68b93qmzy9"
     }
 , freedom-router =
     { dependencies =
@@ -28,6 +36,10 @@
         "https://github.com/purescript-freedom/purescript-freedom-router.git"
     , version =
         "v1.0.0"
+    , rev =
+        "89ca6317d4c24a4646a183e3ea2ad14cabadab3b"
+    , sha256 =
+        "1382hm54kz6sykrnhi26dipc4xizb2g28zganpz8dr1m4daskhfj"
     }
 , freedom-transition =
     { dependencies =
@@ -36,6 +48,10 @@
         "https://github.com/purescript-freedom/purescript-freedom-transition.git"
     , version =
         "v1.0.0"
+    , rev =
+        "e4a73141bc7b8d5b5db603164f9ec0a2f1cc22c3"
+    , sha256 =
+        "1fhmzfh4vx0lr0iry72rsr8kjlpjaq8bvz0m5dflv7xxdyj724gv"
     }
 , freedom-virtualized =
     { dependencies =
@@ -44,6 +60,10 @@
         "https://github.com/purescript-freedom/purescript-freedom-virtualized.git"
     , version =
         "v1.0.0"
+    , rev =
+        "415cda957835f83d7f95883456237d2a8c07bc0d"
+    , sha256 =
+        "06qcqdhyv940db9cj4f6xwz3my36k1rk7zj501qzwl6sy3zzv9bb"
     }
 , freedom-window-resize =
     { dependencies =
@@ -52,5 +72,9 @@
         "https://github.com/purescript-freedom/purescript-freedom-window-resize.git"
     , version =
         "v1.0.0"
+    , rev =
+        "a801a362c65813661af05616e4c06396d50e9ade"
+    , sha256 =
+        "1hz4qqyicvxmk9jwiygvpfpx5s4k5hzhs6fglm6pp5skcszc34c3"
     }
 }

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -5,6 +5,10 @@
         "https://github.com/purescript-node/purescript-node-buffer.git"
     , version =
         "v5.0.0"
+    , rev =
+        "d279daa1b4bf9fe85d5c3aeb96512df4f12e0bc0"
+    , sha256 =
+        "0ih2y29srdxgn526fw2v1y95hpivjil44vkl93w6nrqsymki36y0"
     }
 , node-child-process =
     { dependencies =
@@ -22,6 +26,10 @@
         "https://github.com/purescript-node/purescript-node-child-process.git"
     , version =
         "v6.0.0"
+    , rev =
+        "887b252ef85975f4cf31dfd9079f6d98d905fc1b"
+    , sha256 =
+        "1r5gx9gr5xkrbvdnv6704zmpb987dgpblmhq5yhwq2xir6w35qnn"
     }
 , node-fs =
     { dependencies =
@@ -48,6 +56,10 @@
         "https://github.com/purescript-node/purescript-node-fs.git"
     , version =
         "v5.0.1"
+    , rev =
+        "02d610f237dc130edb5ee594fd46b16c691b79eb"
+    , sha256 =
+        "0i3bd7aw16vyb5sh5fzlvgg9q6cjdvmnfs57in6rxm34z8d8c0p8"
     }
 , node-fs-aff =
     { dependencies =
@@ -56,6 +68,10 @@
         "https://github.com/purescript-node/purescript-node-fs-aff.git"
     , version =
         "v6.0.0"
+    , rev =
+        "d02c0a209824c3fce8254dddd94d85990e9ad1b6"
+    , sha256 =
+        "0vjc9zag7y20yxhhv45hrwv9fbpmp0szv40vaxl5x8mnd5wv28x7"
     }
 , node-http =
     { dependencies =
@@ -77,6 +93,10 @@
         "https://github.com/purescript-node/purescript-node-http.git"
     , version =
         "v5.0.2"
+    , rev =
+        "b18d054de436ad589d41acee0aca7f3bd6762aab"
+    , sha256 =
+        "0jr9mm0kdvkd3nf1g4l8w9p7n16qqji03fg1agxn7hngr4ja43pw"
     }
 , node-net =
     { dependencies =
@@ -96,6 +116,10 @@
         "https://github.com/purescript-node/purescript-node-net.git"
     , version =
         "v1.0.0"
+    , rev =
+        "1fd91c872ecff202ae86b848f2c8d054f7a751f3"
+    , sha256 =
+        "0ya6k6lnva1d7cm93nzb7q8wg5527yjsb04g72acnw4mnqsns5fs"
     }
 , node-path =
     { dependencies =
@@ -104,6 +128,10 @@
         "https://github.com/purescript-node/purescript-node-path.git"
     , version =
         "v3.0.0"
+    , rev =
+        "e3a704d5fc7d25fa93c6cd0eb92dbce9e5ebd69a"
+    , sha256 =
+        "0j1ni52m62dpcrfakl1ik131i31bkg91yv0p1c40sdw0f59fzf6x"
     }
 , node-process =
     { dependencies =
@@ -119,6 +147,10 @@
         "https://github.com/purescript-node/purescript-node-process.git"
     , version =
         "v7.0.0"
+    , rev =
+        "88871d84a69f47dd2d1d9eccd7cc942be4457d46"
+    , sha256 =
+        "1sbhpz3d3r6z12cx1k7rb6nycxf9cyc61zdx6mvk2q2lmzfdm1if"
     }
 , node-readline =
     { dependencies =
@@ -133,6 +165,10 @@
         "https://github.com/purescript-node/purescript-node-readline.git"
     , version =
         "v4.0.1"
+    , rev =
+        "0d61e645aa33142ddd46f63048fe16605f9b8b2a"
+    , sha256 =
+        "1qc0wgcmhcjv15xlq2iqmhr7nphsnsipazpf2flnh7z109kmxj30"
     }
 , node-streams =
     { dependencies =
@@ -141,6 +177,10 @@
         "https://github.com/purescript-node/purescript-node-streams.git"
     , version =
         "v4.0.1"
+    , rev =
+        "88740eeda2017d3ddcde50eea59d57c7749d8524"
+    , sha256 =
+        "12dki2li0d7s54kvcr6gksb5nxf6kzs93gwxnq4bh1flri8p0i7r"
     }
 , node-url =
     { dependencies =
@@ -149,6 +189,10 @@
         "https://github.com/purescript-node/purescript-node-url.git"
     , version =
         "v4.0.0"
+    , rev =
+        "20eecd603124bf07b477f1f2be2135ae99c885fe"
+    , sha256 =
+        "0qbpdz62psy7hb34hw5rw2x1pq7yhd214ysza0xh46c3nlp0ib9y"
     }
 , posix-types =
     { dependencies =
@@ -157,5 +201,9 @@
         "https://github.com/purescript-node/purescript-posix-types.git"
     , version =
         "v4.0.0"
+    , rev =
+        "1d4cd274436cc1e470dc6bf7735bcfdf0092d884"
+    , sha256 =
+        "0xvxjvxr7n4dv53p8w5qfmgx37cga5bp2rjhkbfvj89rb74vm3i1"
     }
 }

--- a/src/groups/purescript-spec.dhall
+++ b/src/groups/purescript-spec.dhall
@@ -18,5 +18,9 @@
         "https://github.com/purescript-spec/purescript-spec.git"
     , version =
         "v4.0.0"
+    , rev =
+        "12bc11c4410dbd8060a6893fe5d07f350e4bb8ab"
+    , sha256 =
+        "1b1hw3231ha5fq61948dfz28a0lm2mcn2pksszf7yw3137ysp5bn"
     }
 }

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -5,6 +5,10 @@
         "https://github.com/purescript-web/purescript-canvas.git"
     , version =
         "v4.0.0"
+    , rev =
+        "bbdc02388f2cc612324aa8c1eef7877666bf1bd2"
+    , sha256 =
+        "0m7a523hr6jn8wg3d1jck1s3bar81gq4ar8bq658sbsysh73n1py"
     }
 , web-clipboard =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/purescript-web/purescript-web-clipboard.git"
     , version =
         "v2.0.0"
+    , rev =
+        "5c4fe20111b9e37d74c805101b5c558928808971"
+    , sha256 =
+        "17i7rpzxi7pgas32xz8vjcs54m94gnmca3my0p70gzvf3rasnxyx"
     }
 , web-dom =
     { dependencies =
@@ -21,6 +29,10 @@
         "https://github.com/purescript-web/purescript-web-dom.git"
     , version =
         "v3.0.0"
+    , rev =
+        "0c47ae3e37407c10789712137381f7899d1ac3a0"
+    , sha256 =
+        "14mssfhg81diy82wbv3ja8zk9a92267c6svq4bgfag91hydw4p42"
     }
 , web-events =
     { dependencies =
@@ -29,6 +41,10 @@
         "https://github.com/purescript-web/purescript-web-events.git"
     , version =
         "v2.0.1"
+    , rev =
+        "7f19f24d7b61066bef0813734964f2dc6b085e3d"
+    , sha256 =
+        "1vd1gfh6zv50bq4v1ppl2wvc5mskcw9n1bfj29qjg0dx0ffxzv2f"
     }
 , web-file =
     { dependencies =
@@ -37,6 +53,10 @@
         "https://github.com/purescript-web/purescript-web-file.git"
     , version =
         "v2.1.1"
+    , rev =
+        "5245d62ba35357c6fb74fa919797d2b7c08110cd"
+    , sha256 =
+        "08k0xv9zpg040v32k3wk66bhzx16c2nn9v35f01gq96anhm713s1"
     }
 , web-html =
     { dependencies =
@@ -45,6 +65,10 @@
         "https://github.com/purescript-web/purescript-web-html.git"
     , version =
         "v2.2.1"
+    , rev =
+        "6f0d367f737202fdf9638f1f6836716c26456014"
+    , sha256 =
+        "026y4kkrc2z4zmxlc4z21znq8knaqqjazf1ny811gm1507b1ykc6"
     }
 , web-socket =
     { dependencies =
@@ -53,6 +77,10 @@
         "https://github.com/purescript-web/purescript-web-socket.git"
     , version =
         "v2.0.0"
+    , rev =
+        "00f4ab583efb6fc60e0517d782d2ba2a89d8ec66"
+    , sha256 =
+        "0kp4rmrqmsjmih7nw7dl75d36pny3ikafnhnfchpc834ap9451zh"
     }
 , web-storage =
     { dependencies =
@@ -61,6 +89,10 @@
         "https://github.com/purescript-web/purescript-web-storage.git"
     , version =
         "v3.0.0"
+    , rev =
+        "c2dedea1ee10ca7e94af5547c90274fb63ab3bc6"
+    , sha256 =
+        "1ycb2s29aw9w6lqik6hfmp9nf9i2yhn0q26hc4p3450jam5mj8bx"
     }
 , web-touchevents =
     { dependencies =
@@ -69,6 +101,10 @@
         "https://github.com/purescript-web/purescript-web-touchevents.git"
     , version =
         "v2.0.0"
+    , rev =
+        "cde8ea42d92035b1c46df4f1e1c38205aba7742a"
+    , sha256 =
+        "0mhsfqlglx04q3vkjg4k33bkxcpx2cmbq4x1zxyhl48q1qqmnic8"
     }
 , web-uievents =
     { dependencies =
@@ -77,6 +113,10 @@
         "https://github.com/purescript-web/purescript-web-uievents.git"
     , version =
         "v2.0.0"
+    , rev =
+        "bdbc845bf8b06649c8361411085a0c0f788c9511"
+    , sha256 =
+        "04032nl0z9hjq7b799zhbn7in10dz9kgrrcs0adjbaf08rc2kcwh"
     }
 , web-xhr =
     { dependencies =
@@ -90,5 +130,9 @@
         "https://github.com/purescript-web/purescript-web-xhr.git"
     , version =
         "v3.0.1"
+    , rev =
+        "eb1db72a670b3b98877f33940dbe37097b722736"
+    , sha256 =
+        "1217lmvla3rqd9kzvvjxpngj7nxjn2ianm9xhlc0iydzsd0agihi"
     }
 }

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -17,6 +17,10 @@
         "https://github.com/purescript/purescript-arrays.git"
     , version =
         "v5.3.0"
+    , rev =
+        "1bca4c0b8904e65d356ed6d8db8d6f7e071132d3"
+    , sha256 =
+        "0r991qcx69xj07iagjaxkm0ab9qi2pw8cs3qwyybhis7asd6bnz6"
     }
 , assert =
     { dependencies =
@@ -25,6 +29,10 @@
         "https://github.com/purescript/purescript-assert.git"
     , version =
         "v4.1.0"
+    , rev =
+        "2044562f3c7c49c36ef4e63490031ed534589f6c"
+    , sha256 =
+        "06l3ldmlmpz9pcpy8k578haa3pq67b733rvcpl5i3f69h6ymhz0n"
     }
 , bifunctors =
     { dependencies =
@@ -33,6 +41,10 @@
         "https://github.com/purescript/purescript-bifunctors.git"
     , version =
         "v4.0.0"
+    , rev =
+        "1062425892b4a1c734ec653dded22546e3063b27"
+    , sha256 =
+        "1bdra5fbkraglqrrm484vw8h0wwk48kzkn586v4y7fg106q1q386"
     }
 , catenable-lists =
     { dependencies =
@@ -48,6 +60,10 @@
         "https://github.com/purescript/purescript-catenable-lists.git"
     , version =
         "v5.0.1"
+    , rev =
+        "d81b7df30d9879d0bb531b3102fb36f429c2f12e"
+    , sha256 =
+        "0mbpb8xr9a7a4bvawhki7js5cbv7c0lv0vdwb6r8nmv6b61gzg27"
     }
 , console =
     { dependencies =
@@ -56,6 +72,10 @@
         "https://github.com/purescript/purescript-console.git"
     , version =
         "v4.2.0"
+    , rev =
+        "add2bdb8a4af2213d993b728805f1f2a5e76deb8"
+    , sha256 =
+        "1b2nykdq1dzaqyra5pi8cvvz4dsbbkg57a2c88yi931ynm19nnw6"
     }
 , const =
     { dependencies =
@@ -69,6 +89,10 @@
         "https://github.com/purescript/purescript-const.git"
     , version =
         "v4.1.0"
+    , rev =
+        "bc5db27b0ed3947fa5e2074ccbab01236eec3fa4"
+    , sha256 =
+        "0qbd2aisax52yw6sybdhs7na943cbsd6mylhhgsamrf7hzh6v51p"
     }
 , contravariant =
     { dependencies =
@@ -77,6 +101,10 @@
         "https://github.com/purescript/purescript-contravariant.git"
     , version =
         "v4.0.1"
+    , rev =
+        "cb69db0253c2e2ed3fef784dad58f3418a8ee834"
+    , sha256 =
+        "0dd17lwlybpz4i54cxnqdgy38rjlbw9p7bw1r43is6z3kdc8983a"
     }
 , control =
     { dependencies =
@@ -85,6 +113,10 @@
         "https://github.com/purescript/purescript-control.git"
     , version =
         "v4.1.0"
+    , rev =
+        "8af53eea4ecc7b185776a0f144bcd7106ed08eb1"
+    , sha256 =
+        "10703zvsnjm5fc74k6wzjsvpsfyc3jci3jxhm7rxf7ymya9z1z53"
     }
 , datetime =
     { dependencies =
@@ -109,6 +141,10 @@
         "https://github.com/purescript/purescript-datetime.git"
     , version =
         "v4.1.1"
+    , rev =
+        "9e76abe96f45a68eb0bb23d0afd56031a8070bee"
+    , sha256 =
+        "06ghfvbvd5sd0q014qi8j8glk2g2j9f8z8cwq2318kllp92gz07q"
     }
 , distributive =
     { dependencies =
@@ -117,6 +153,10 @@
         "https://github.com/purescript/purescript-distributive.git"
     , version =
         "v4.0.0"
+    , rev =
+        "3a43c0690883816e9ebeac510698423cfff5c174"
+    , sha256 =
+        "0zbn0yq1vv7fbbf1lncg80irz0vg7wnw9b9wrzxhdzpbkw4jinsl"
     }
 , effect =
     { dependencies =
@@ -125,6 +165,10 @@
         "https://github.com/purescript/purescript-effect.git"
     , version =
         "v2.0.1"
+    , rev =
+        "6caa8e1e162a21eed025613c2c19194b996ef779"
+    , sha256 =
+        "1vqw5wrdxzh1ww6z7271xr4kg4mx0r3k3mwg18dmgmzj11wbn2wh"
     }
 , either =
     { dependencies =
@@ -139,6 +183,10 @@
         "https://github.com/purescript/purescript-either.git"
     , version =
         "v4.1.1"
+    , rev =
+        "8b4b38a729f8e88750b03e5c7baf2b3863ce4742"
+    , sha256 =
+        "12j7vvjly0bgxidxmb2pflx0zy7x425dnvxk2y1pm66n0hbsq7ns"
     }
 , enums =
     { dependencies =
@@ -157,6 +205,10 @@
         "https://github.com/purescript/purescript-enums.git"
     , version =
         "v4.0.1"
+    , rev =
+        "19800105b556798ea5650f8a01bfe5ea17cfc6eb"
+    , sha256 =
+        "0qq0pgmq497nfml0y8xb2qdpga5xqp9sqq4ilv1rpyhg1v7nzb6v"
     }
 , exceptions =
     { dependencies =
@@ -165,6 +217,10 @@
         "https://github.com/purescript/purescript-exceptions.git"
     , version =
         "v4.0.0"
+    , rev =
+        "9012eb08749e9ccd5da45bdece5d576e5fc0b0db"
+    , sha256 =
+        "17s0rg9k4phivhx9j3l2vqqfdhk61gpj1xfqy8w6zj3rnxj0b2cv"
     }
 , exists =
     { dependencies =
@@ -173,6 +229,10 @@
         "https://github.com/purescript/purescript-exists.git"
     , version =
         "v4.0.0"
+    , rev =
+        "ef53359aebc09bf863800ca86ad1dcd76f0b08ae"
+    , sha256 =
+        "0bbdbw3jaqyi8dj2d52zvfgx4vl84d8cr6hp43vy8lfjfcbj0wlk"
     }
 , foldable-traversable =
     { dependencies =
@@ -181,6 +241,10 @@
         "https://github.com/purescript/purescript-foldable-traversable.git"
     , version =
         "v4.1.1"
+    , rev =
+        "29d5b873cc86f17e0082d777629819a96bdbc7a1"
+    , sha256 =
+        "03x89xcmphckzjlp4chc7swrpw347ll5bvr2yp7x9v2jqw2jlyi1"
     }
 , foreign =
     { dependencies =
@@ -198,6 +262,10 @@
         "https://github.com/purescript/purescript-foreign.git"
     , version =
         "v5.0.0"
+    , rev =
+        "3b8f3ae608db339ed5cff35d2017a07efb905b4d"
+    , sha256 =
+        "15mz2s4f8crkd721z4df2aag4s0wil6fs07cpcmi7dpnkn7a4nab"
     }
 , foreign-object =
     { dependencies =
@@ -218,6 +286,10 @@
         "https://github.com/purescript/purescript-foreign-object.git"
     , version =
         "v2.0.3"
+    , rev =
+        "8a7dc21c48e3e6d31e253b0e58dd95a3bbd7f6e7"
+    , sha256 =
+        "07wiql59zfj901nk9526b6rykn9m24jjcs8v5dgxbr1c3hiab9n3"
     }
 , free =
     { dependencies =
@@ -240,6 +312,10 @@
         "https://github.com/purescript/purescript-free.git"
     , version =
         "v5.2.0"
+    , rev =
+        "f686f5fc07766f3ca9abc83b47b6ad3da326759a"
+    , sha256 =
+        "1bwj0ay7q9lm4ir29jy549m05jvaqik1s615biv23y51ngx3fn49"
     }
 , functions =
     { dependencies =
@@ -248,6 +324,10 @@
         "https://github.com/purescript/purescript-functions.git"
     , version =
         "v4.0.0"
+    , rev =
+        "c63451ae74f6fba7a4eede5f87208a73c537af77"
+    , sha256 =
+        "0675k5kxxwdvsjs6a3is8pwm3hmv0vbcza1b8ls10gymmfz3k3hj"
     }
 , functors =
     { dependencies =
@@ -266,6 +346,10 @@
         "https://github.com/purescript/purescript-functors.git"
     , version =
         "v3.1.1"
+    , rev =
+        "96bcf8a970a40115a76a20d19e50aa3b524adcf3"
+    , sha256 =
+        "1cnn3zhk6qcyiwbbpvrdqgsbch4qihx2y9d6sv45bvd8kzrbd306"
     }
 , gen =
     { dependencies =
@@ -284,6 +368,10 @@
         "https://github.com/purescript/purescript-gen.git"
     , version =
         "v2.1.1"
+    , rev =
+        "36f36f03f082b57e402c27f1513f8935caa54101"
+    , sha256 =
+        "0pk68cn1s89hql30ydks9gh34gbxg391smi2albx3qvxnfkrpxca"
     }
 , generics-rep =
     { dependencies =
@@ -292,6 +380,10 @@
         "https://github.com/purescript/purescript-generics-rep.git"
     , version =
         "v6.1.1"
+    , rev =
+        "aae27ba1de21dda342dcdfc8b3cc5b951bd5b3ec"
+    , sha256 =
+        "15vchzbcvf6byks90q14lvcwb8hnxqzm2mrlxi7v1f7has4s74kn"
     }
 , globals =
     { dependencies =
@@ -300,6 +392,10 @@
         "https://github.com/purescript/purescript-globals.git"
     , version =
         "v4.0.0"
+    , rev =
+        "3c6251da362312d439a19c0939ae98653a7d4d65"
+    , sha256 =
+        "150mc0kv0cb5fkx0szicwczjr54bglmlyaynj2grf1r4gnjg967s"
     }
 , identity =
     { dependencies =
@@ -308,6 +404,10 @@
         "https://github.com/purescript/purescript-identity.git"
     , version =
         "v4.1.0"
+    , rev =
+        "1b7938abdc8cb28c0ac5f80f63405d53e3173a8e"
+    , sha256 =
+        "1scdgbfkphfmapw7p9rnsiynpmqzyvnal2glzj450q51f8g1dhld"
     }
 , integers =
     { dependencies =
@@ -316,6 +416,10 @@
         "https://github.com/purescript/purescript-integers.git"
     , version =
         "v4.0.0"
+    , rev =
+        "3850da9cd96b37c71685b6bc3bf0cb489baefc93"
+    , sha256 =
+        "17d4bfpnrmbxlc7hhhrvnli70ydaqyr26zgvc9q52a76zgdcb4cf"
     }
 , invariant =
     { dependencies =
@@ -324,6 +428,10 @@
         "https://github.com/purescript/purescript-invariant.git"
     , version =
         "v4.1.0"
+    , rev =
+        "b704c5bda262719ca5cc88a3f8554edff8f03256"
+    , sha256 =
+        "1fimpbh3yb7clvqxcdf4yf9im64z0v2s9pbspfacgq5b4vshjas9"
     }
 , lazy =
     { dependencies =
@@ -332,6 +440,10 @@
         "https://github.com/purescript/purescript-lazy.git"
     , version =
         "v4.0.0"
+    , rev =
+        "5bbd04f507a704f39aa756b5e12ed6665205fe2e"
+    , sha256 =
+        "156q89l4nvvn14imbhp6xvvm82q7kqh1pyndmldmnkhiqyr84vqv"
     }
 , lcg =
     { dependencies =
@@ -347,6 +459,10 @@
         "https://github.com/purescript/purescript-lcg.git"
     , version =
         "v2.0.0"
+    , rev =
+        "596bcb17bd550397735220f919df52bcd0038fe0"
+    , sha256 =
+        "1851cq2g84jzjbvbmncbivbhaqzj9zv5ni3gs14k04nmx2brxmvj"
     }
 , lists =
     { dependencies =
@@ -367,6 +483,10 @@
         "https://github.com/purescript/purescript-lists.git"
     , version =
         "v5.4.1"
+    , rev =
+        "62900a56f6864638c952575dfd211a1cc55be7da"
+    , sha256 =
+        "0l0jiqhcjzkg4nv2a6h2vdf4izr9mf7cxc86cq1hf3j4dh6spym1"
     }
 , math =
     { dependencies =
@@ -375,6 +495,10 @@
         "https://github.com/purescript/purescript-math.git"
     , version =
         "v2.1.1"
+    , rev =
+        "8be36d24f9d2d8795adf04791446bbc458297b9b"
+    , sha256 =
+        "1msmy9w7y6fij62sdc55w68gpwkhm6lhgc8qjisjk4sxx1wdg1rr"
     }
 , maybe =
     { dependencies =
@@ -383,6 +507,10 @@
         "https://github.com/purescript/purescript-maybe.git"
     , version =
         "v4.0.1"
+    , rev =
+        "81f0397636bcbca28642f62421aebfd9e1afa7fb"
+    , sha256 =
+        "073wa0d51daxdwacfcxg5pf6ch63n4ii55xm1ih87bxrg8mp52mx"
     }
 , minibench =
     { dependencies =
@@ -399,6 +527,10 @@
         "https://github.com/purescript/purescript-minibench.git"
     , version =
         "v2.0.0"
+    , rev =
+        "a9cc6d74730bdcf21bd6962cd640a3744fe6c14b"
+    , sha256 =
+        "166hbl30bd3x14fld77f97h9bpkq3z775g3ymk61nsnfpf640p22"
     }
 , newtype =
     { dependencies =
@@ -407,6 +539,10 @@
         "https://github.com/purescript/purescript-newtype.git"
     , version =
         "v3.0.0"
+    , rev =
+        "7d85fa6a040208c010b05f7c23af6a943ba08763"
+    , sha256 =
+        "0qvk9p41miy806b05b4ikbr3if0fcyc35gfrwd2mflcxxp46011c"
     }
 , nonempty =
     { dependencies =
@@ -421,6 +557,10 @@
         "https://github.com/purescript/purescript-nonempty.git"
     , version =
         "v5.0.0"
+    , rev =
+        "36ca3b2fa6d98b1c9d2ee05643341e496fbeab57"
+    , sha256 =
+        "1vz174sg32cqrp52nwb2vz9frrzmdwzzlgl4vc2cm5wlf2anirxj"
     }
 , ordered-collections =
     { dependencies =
@@ -441,6 +581,10 @@
         "https://github.com/purescript/purescript-ordered-collections.git"
     , version =
         "v1.6.1"
+    , rev =
+        "54af8b281bf01acfc14e147debec76974901e93c"
+    , sha256 =
+        "0r48p94d3cyzni2z7ikzcap472k23dx8zq37c1prmjb01v03mfvc"
     }
 , orders =
     { dependencies =
@@ -449,6 +593,10 @@
         "https://github.com/purescript/purescript-orders.git"
     , version =
         "v4.0.0"
+    , rev =
+        "80e22c22c72c846e09ef9dfcdb40b3eee39118d6"
+    , sha256 =
+        "13p1sm4dxkmxhld9x5qqg62iiajjb3qpzs66c1r24y5fs4zsfry4"
     }
 , parallel =
     { dependencies =
@@ -467,6 +615,10 @@
         "https://github.com/purescript/purescript-parallel.git"
     , version =
         "v4.0.0"
+    , rev =
+        "4d6c8b05041a36c300dfca2ba8f1f3443ca26bc6"
+    , sha256 =
+        "1d5bnagabw2k8yxywkygwrpblb2ggqh2fhpqfrx2sj1y53x332hg"
     }
 , partial =
     { dependencies =
@@ -475,6 +627,10 @@
         "https://github.com/purescript/purescript-partial.git"
     , version =
         "v2.0.1"
+    , rev =
+        "76b63a324f7eafbb859256771b5bb7404082af96"
+    , sha256 =
+        "11qr80989g7xmvw1brnrclsbg2wdkbr5k3cqpngfip3nnirrypcn"
     }
 , prelude =
     { dependencies =
@@ -483,6 +639,10 @@
         "https://github.com/purescript/purescript-prelude.git"
     , version =
         "v4.1.1"
+    , rev =
+        "a96663b34364fdd0885a200955e35b99f4e58c43"
+    , sha256 =
+        "1frvjrv0mr508r6683l1mp5rzm1y2dz76fz40zf4k2c64sy6y1xm"
     }
 , profunctor =
     { dependencies =
@@ -500,6 +660,10 @@
         "https://github.com/purescript/purescript-profunctor.git"
     , version =
         "v4.0.0"
+    , rev =
+        "1de584baf49624cc0d1686067d82b93523654c1b"
+    , sha256 =
+        "1v4kvmhmiwznd4lswp9339h64pgv5zvd3vm1q7gzj70767a3941i"
     }
 , proxy =
     { dependencies =
@@ -508,6 +672,10 @@
         "https://github.com/purescript/purescript-proxy.git"
     , version =
         "v3.0.0"
+    , rev =
+        "4a529b1f874fa2f32fc4c575cafaf46e0ab69fb6"
+    , sha256 =
+        "0rqf25b1n9p5sgx7gdsxwrfv9rb3sqxgqmqpp5kdm30lfk7snz24"
     }
 , psci-support =
     { dependencies =
@@ -516,6 +684,10 @@
         "https://github.com/purescript/purescript-psci-support.git"
     , version =
         "v4.0.0"
+    , rev =
+        "a66a0fa8661eb8b5fe75cc862f4e2df2835c058d"
+    , sha256 =
+        "0jd773zcklr6hjddqingzmk20a0afpm2r9pczfjbj0d93pbxb4xh"
     }
 , quickcheck =
     { dependencies =
@@ -552,6 +724,10 @@
         "https://github.com/purescript/purescript-quickcheck.git"
     , version =
         "v6.1.0"
+    , rev =
+        "6289a80570acd5aec3ea89dc673cf10cdaf5794a"
+    , sha256 =
+        "0b6208067krf81kzq2hbxs68386hcicbscwxbj5nck07ivjjvqh0"
     }
 , random =
     { dependencies =
@@ -560,6 +736,10 @@
         "https://github.com/purescript/purescript-random.git"
     , version =
         "v4.0.0"
+    , rev =
+        "75e6b21edbe0eec78c28ff3bd8265998f2ea0b45"
+    , sha256 =
+        "0k37v7z529adx6ypxj0xjyfrz45qia6p0vki2wpvi8lik7c698gf"
     }
 , record =
     { dependencies =
@@ -568,6 +748,10 @@
         "https://github.com/purescript/purescript-record.git"
     , version =
         "v2.0.1"
+    , rev =
+        "42a15ba34d860f4d8f899836956bf09659a0256b"
+    , sha256 =
+        "1l7ixb0gc2man36181g3hdf46sjp7xh0kv8bgrvalxfisjmd12v0"
     }
 , refs =
     { dependencies =
@@ -576,6 +760,10 @@
         "https://github.com/purescript/purescript-refs.git"
     , version =
         "v4.1.0"
+    , rev =
+        "e8b175477661e433175e76548168290c40e0ce4b"
+    , sha256 =
+        "08161iy1xbafzblv033v84156azpcqkiw9v9d6gliphrq5fm17gm"
     }
 , semirings =
     { dependencies =
@@ -584,6 +772,10 @@
         "https://github.com/purescript/purescript-semirings.git"
     , version =
         "v5.0.0"
+    , rev =
+        "36aedc601d296607439eec1e71f8483adc373ffc"
+    , sha256 =
+        "0bhrhn2yvcgil7g63spb2xw966mdhlk9mpspnqfijdpb9n3b79ds"
     }
 , st =
     { dependencies =
@@ -592,6 +784,10 @@
         "https://github.com/purescript/purescript-st.git"
     , version =
         "v4.0.0"
+    , rev =
+        "c1b9a0d47a5be1d7ea713ef1c583040eb332250a"
+    , sha256 =
+        "0m2jkb9dmpbr8s1c20l7sm2q11y5rx8gqfiyspnyhq5apzkknjr0"
     }
 , strings =
     { dependencies =
@@ -616,6 +812,10 @@
         "https://github.com/purescript/purescript-strings.git"
     , version =
         "v4.0.1"
+    , rev =
+        "94c843b93142d0edf1c31ec075c40b6984c3dc7b"
+    , sha256 =
+        "147l3l3fzn7liparhm2y3p8j4ck1lblra5j493p2hy5yy5ndznc8"
     }
 , tailrec =
     { dependencies =
@@ -632,6 +832,10 @@
         "https://github.com/purescript/purescript-tailrec.git"
     , version =
         "v4.0.0"
+    , rev =
+        "69f4625969e313203028968e4a9f743fa7f87883"
+    , sha256 =
+        "0z7k80nl8dgv8mc2w8xsl2n0637bd1l8ppxak8kaifgjjwa81hx3"
     }
 , transformers =
     { dependencies =
@@ -654,6 +858,10 @@
         "https://github.com/purescript/purescript-transformers.git"
     , version =
         "v4.2.0"
+    , rev =
+        "0e473e5ef0e294615ca0d9aab0bcffee47b2870d"
+    , sha256 =
+        "03qmvl9s7lbvm73dy9ps6qp39pdcm91hb8yakgj7aq8hgpj7b6bg"
     }
 , tuples =
     { dependencies =
@@ -671,6 +879,10 @@
         "https://github.com/purescript/purescript-tuples.git"
     , version =
         "v5.1.0"
+    , rev =
+        "0036bf9d99b721fd0f2e539d24e18e484b016927"
+    , sha256 =
+        "045nsy0r2g51gih0wjhcvhl6gfr8947mlrqwg644ygz72rjm8wq4"
     }
 , type-equality =
     { dependencies =
@@ -679,6 +891,10 @@
         "https://github.com/purescript/purescript-type-equality.git"
     , version =
         "v3.0.0"
+    , rev =
+        "2cdae51c394401cd5fc04b03c341273b41532b7d"
+    , sha256 =
+        "1b7szyca5s96gaawvgwrw7fa8r7gqsdff7xhz3vvngnylv2scl3w"
     }
 , typelevel-prelude =
     { dependencies =
@@ -687,6 +903,10 @@
         "https://github.com/purescript/purescript-typelevel-prelude.git"
     , version =
         "v5.0.0"
+    , rev =
+        "82b343fabfe3bf4ebf8106ce61bfe24fb3ed500c"
+    , sha256 =
+        "01ki39xj87kwf8j8divlzwrvfyjcgxpmzhhmxzjylqx6jarcwyg6"
     }
 , unfoldable =
     { dependencies =
@@ -695,6 +915,10 @@
         "https://github.com/purescript/purescript-unfoldable.git"
     , version =
         "v4.0.2"
+    , rev =
+        "be3262a9dc48e794676b1b2883987331d4be6fd7"
+    , sha256 =
+        "0lzhx030c5933maxcjwk6kzlvbxky1kiwrymqf1dp5wbrar3jyv4"
     }
 , unsafe-coerce =
     { dependencies =
@@ -703,6 +927,10 @@
         "https://github.com/purescript/purescript-unsafe-coerce.git"
     , version =
         "v4.0.0"
+    , rev =
+        "fa6a5ca9b4581c00ee0b8539306a49badb7bee60"
+    , sha256 =
+        "0k9255mk2mz6xjb11pwkgfcblmmyvr86ig5kr92jwy95xim09zip"
     }
 , validation =
     { dependencies =
@@ -717,5 +945,9 @@
         "https://github.com/purescript/purescript-validation.git"
     , version =
         "v4.2.0"
+    , rev =
+        "bef3f9da737516e69f00d35310334004c29355cb"
+    , sha256 =
+        "03irk6n7jgsimhp9ckrg2ns7qbc8d383ls3sslxgir5mr8xdc44g"
     }
 }

--- a/src/groups/reactormonk.dhall
+++ b/src/groups/reactormonk.dhall
@@ -13,6 +13,10 @@
         "https://github.com/reactormonk/purescript-rave.git"
     , version =
         "v0.1.1"
+    , rev =
+        "5375bba51f57ab272994da335b36ddfaedbc5940"
+    , sha256 =
+        "0avia2yix0vqi4r817c2yll2s5ng8ycglcpn1iygibji4w0dkr1a"
     }
 , simple-timestamp =
     { dependencies =
@@ -30,5 +34,9 @@
         "https://github.com/reactormonk/purescript-simple-timestamp.git"
     , version =
         "v1.3.0"
+    , rev =
+        "8e219b4b57a8679885d645050057b5a567685fad"
+    , sha256 =
+        "0p2w88mkvsy9yfn4vgm4s6hzpc9lxsyq6qna3n3b7v3jm1n7gpdz"
     }
 }

--- a/src/groups/rightfold.dhall
+++ b/src/groups/rightfold.dhall
@@ -18,6 +18,10 @@
         "https://github.com/rightfold/purescript-bytestrings.git"
     , version =
         "v7.0.0"
+    , rev =
+        "2d58bc68ac1d3650ee2a4f620057f526043f6352"
+    , sha256 =
+        "1wnzlbjbsz8mhn1lw47xwql5lms82a9kghk6swa78k22zw5xwzlm"
     }
 , quotient =
     { dependencies =
@@ -26,5 +30,9 @@
         "https://github.com/rightfold/purescript-quotient.git"
     , version =
         "v3.0.0"
+    , rev =
+        "cd7ab1fd0ece7f14ba85a0e6a5b87d863426c054"
+    , sha256 =
+        "0qkdw2kyf0p7mchi84dw8wm2jw58a2gii7wfjnddgn3j5jg36l2y"
     }
 }

--- a/src/groups/risto-stevcev.dhall
+++ b/src/groups/risto-stevcev.dhall
@@ -5,5 +5,9 @@
         "https://github.com/Risto-Stevcev/purescript-exitcodes.git"
     , version =
         "v4.0.0"
+    , rev =
+        "8a9a93fd1776aba4a14cdc9a31094c9e05b05348"
+    , sha256 =
+        "16861bn1h6jz47i20sd2a0d3qdj52akkqpx43yllmsdggcawmjxc"
     }
 }

--- a/src/groups/rnons.dhall
+++ b/src/groups/rnons.dhall
@@ -5,6 +5,10 @@
         "https://github.com/rnons/purescript-svg-parser.git"
     , version =
         "v1.0.0"
+    , rev =
+        "3497fadad2af220f13fb01ef3c7d45cdd505a786"
+    , sha256 =
+        "0a397vkj67j3rkmq25q85m8n8336kwz0vdfpg28m295i49vlhn6s"
     }
 , svg-parser-halogen =
     { dependencies =
@@ -13,5 +17,9 @@
         "https://github.com/rnons/purescript-svg-parser-halogen.git"
     , version =
         "v1.0.0"
+    , rev =
+        "a93c86579fbc8b4284250200153cbf5715423e0b"
+    , sha256 =
+        "0cdgx2cp0p47wf33cgpn60l085pmhv8hj5ymcbqb8mqmcw1l1037"
     }
 }

--- a/src/groups/sharkdp.dhall
+++ b/src/groups/sharkdp.dhall
@@ -5,6 +5,10 @@
         "https://github.com/sharkdp/purescript-bigints.git"
     , version =
         "v4.0.0"
+    , rev =
+        "b29a2487899abc3701124701b82993a5fe129378"
+    , sha256 =
+        "1m9v4an4y55rhiknr2spyllf80chl61w2xzmg90p58f8q4mzih8r"
     }
 , colors =
     { dependencies =
@@ -13,6 +17,10 @@
         "https://github.com/sharkdp/purescript-colors.git"
     , version =
         "v5.0.0"
+    , rev =
+        "fb582d3626e566371d20d4ef0b8d2795ee80f024"
+    , sha256 =
+        "05bkfqllfpkh7nj0nzgd5p387hlpk0x35nam1i6xm3vzma9csj18"
     }
 , decimals =
     { dependencies =
@@ -21,6 +29,10 @@
         "https://github.com/sharkdp/purescript-decimals.git"
     , version =
         "v5.0.0"
+    , rev =
+        "4911f744fb7db6519758b6993edc28d0f81e0a89"
+    , sha256 =
+        "1ad56xf8i7mwqlp718ik12dvc8aqwjxfpk7d8hdyjwzhf7b1ws2n"
     }
 , format =
     { dependencies =
@@ -36,6 +48,10 @@
         "https://github.com/sharkdp/purescript-format.git"
     , version =
         "v4.0.0"
+    , rev =
+        "764c4f4a9f7d01f9572cf34449d6a0ffbe3bb89a"
+    , sha256 =
+        "19f9vylx9ybxrwdkm16sh2bzv9xwlmq5yddj52a0s7yi80pkgmn9"
     }
 , numbers =
     { dependencies =
@@ -44,6 +60,10 @@
         "https://github.com/sharkdp/purescript-numbers.git"
     , version =
         "v7.0.0"
+    , rev =
+        "6262a5f17dcdfba11dfae03f4fa8eec02f7ed29f"
+    , sha256 =
+        "1l9s22fkjf7wc0zd3wjax4hlif7gqh6ij0ijb8sq20mfh2xl4hj8"
     }
 , pairs =
     { dependencies =
@@ -52,5 +72,9 @@
         "https://github.com/sharkdp/purescript-pairs.git"
     , version =
         "v7.0.0"
+    , rev =
+        "8c220e4f51c33ef04291cab60af69729f768f8ea"
+    , sha256 =
+        "1zd3fvxw3kpyb066rhmadh97ppfmypsl2q1w23xqaywwzpx2n3a3"
     }
 }

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -12,6 +12,10 @@
         "https://github.com/slamdata/purescript-aff.git"
     , version =
         "v5.1.1"
+    , rev =
+        "390857f9143e1a52f7403d05b14c9ca79d356737"
+    , sha256 =
+        "19v5psd6jz13gr5yqyx8286b5bpfq1dax51w906y0mqgnfz92yzr"
     }
 , aff-bus =
     { dependencies =
@@ -20,6 +24,10 @@
         "https://github.com/slamdata/purescript-aff-bus.git"
     , version =
         "v4.0.0"
+    , rev =
+        "5f60dc3b29b6a37f08eacd210c979dbdfbc8ed76"
+    , sha256 =
+        "17y6gcd8y6sibfkdijl9w0g4vwia0b005nc8jbyhp4svgszcv11x"
     }
 , affjax =
     { dependencies =
@@ -41,6 +49,10 @@
         "https://github.com/slamdata/purescript-affjax.git"
     , version =
         "v9.0.0"
+    , rev =
+        "ec9c50e35980ba33b4bc7a3bc026970ba27bf767"
+    , sha256 =
+        "04xij3q4802z58mzaaz661ifv1rd673fq2mjqj553dw326zplpvs"
     }
 , avar =
     { dependencies =
@@ -49,6 +61,10 @@
         "https://github.com/slamdata/purescript-avar.git"
     , version =
         "v3.0.0"
+    , rev =
+        "17914413130490318a475e9de6a9244aaaa097d2"
+    , sha256 =
+        "14g05jm2xricy5b9vn4k4lhc9lzi5jvpvv85h10s17kn4wwi9igk"
     }
 , css =
     { dependencies =
@@ -65,6 +81,10 @@
         "https://github.com/slamdata/purescript-css.git"
     , version =
         "v4.0.0"
+    , rev =
+        "0164325e66dd59b3b5a4ea53ac8adf7d389b4c8e"
+    , sha256 =
+        "0f6gib6rp20qz08vramw7k6kv2ck315lmshjpii8zmkjb5ya0w55"
     }
 , dom-indexed =
     { dependencies =
@@ -73,6 +93,10 @@
         "https://github.com/slamdata/purescript-dom-indexed.git"
     , version =
         "v7.0.0"
+    , rev =
+        "c449ae115bffe1fce89e145da62b862ad16ed935"
+    , sha256 =
+        "18is75gsiix9w3f3lkly15cvs7ma1qc13hhi6wkl8nsj2g9g55ld"
     }
 , fixed-points =
     { dependencies =
@@ -81,6 +105,10 @@
         "https://github.com/slamdata/purescript-fixed-points.git"
     , version =
         "v5.1.0"
+    , rev =
+        "44ae7a7135bd17dc6d865d31f166a8cf5fa65c7e"
+    , sha256 =
+        "14acfi7897z2vd8mq52h0gz8x31wyrvalb490rqjf4nyk73vhg36"
     }
 , fork =
     { dependencies =
@@ -89,6 +117,10 @@
         "https://github.com/slamdata/purescript-fork.git"
     , version =
         "v4.0.0"
+    , rev =
+        "27b9f223645a08b42731531a154892eaa263b590"
+    , sha256 =
+        "1jygqzyci40c28gw2ygnx8v52hilhajj1bdpn7ndvss4i7yh1lcp"
     }
 , formatters =
     { dependencies =
@@ -104,6 +136,10 @@
         "https://github.com/slamdata/purescript-formatters.git"
     , version =
         "v4.0.1"
+    , rev =
+        "c39ae1fef63a4c5ed6ccb9faf80e6b99922a369b"
+    , sha256 =
+        "1i9dnh7xr6wmmgaphy75m9jdrg3qbjm3ml5fwg4ihy87x9w1fv1l"
     }
 , halogen =
     { dependencies =
@@ -132,6 +168,10 @@
         "https://github.com/slamdata/purescript-halogen.git"
     , version =
         "v5.0.0-rc.6"
+    , rev =
+        "c7583fe8d685702a5c9fea37d051a5cfa5023a07"
+    , sha256 =
+        "1b6ls7ifkzgcbx9sc0xbjmhaq23vx8if76vlkrbfywmkpxdkkrlz"
     }
 , halogen-bootstrap =
     { dependencies =
@@ -140,6 +180,10 @@
         "https://github.com/slamdata/purescript-halogen-bootstrap.git"
     , version =
         "v8.0.0"
+    , rev =
+        "9289a84f989c2572fbdbd49af2fcdd8175d3d7a0"
+    , sha256 =
+        "0cvhq977jd5zs1j6jy9x2cs8yl2mhwy2kmywpvnl5a0sypcza56x"
     }
 , halogen-css =
     { dependencies =
@@ -148,6 +192,10 @@
         "https://github.com/slamdata/purescript-halogen-css.git"
     , version =
         "v8.0.0"
+    , rev =
+        "1600df2902eccc3e3c73559a3446c99469885af6"
+    , sha256 =
+        "1a8sj8ydfnvj3vh2l3f0yyd69y7v4qki1a5m99n0v2aqc1y6nrzl"
     }
 , halogen-vdom =
     { dependencies =
@@ -166,6 +214,10 @@
         "https://github.com/slamdata/purescript-halogen-vdom.git"
     , version =
         "v6.1.0"
+    , rev =
+        "34c032aa5f72b600d69ab970e2737ca533c6c118"
+    , sha256 =
+        "1zsivlk74zn6wkw25mvc12yjnqfjgyfpmhs3rsrvgycnmswdavnk"
     }
 , pathy =
     { dependencies =
@@ -184,6 +236,10 @@
         "https://github.com/slamdata/purescript-pathy.git"
     , version =
         "v7.0.1"
+    , rev =
+        "350ac0bc770c5492786cd40b9998d35fef510b09"
+    , sha256 =
+        "09nnwb51sr0mfma0hfrh23f314h3zrn2gwanq3n75asx3r6vqjif"
     }
 , routing =
     { dependencies =
@@ -207,6 +263,10 @@
         "https://github.com/slamdata/purescript-routing.git"
     , version =
         "v9.0.0"
+    , rev =
+        "62742c314b7a30118399f1b98fdec27212f8f40e"
+    , sha256 =
+        "1q05k1nrwpmlwy35fwa6kp1drk1ywnf5srmm1rzpliprvpli3is7"
     }
 , uri =
     { dependencies =
@@ -225,5 +285,9 @@
         "https://github.com/slamdata/purescript-uri.git"
     , version =
         "v7.0.0"
+    , rev =
+        "e48b2e9153aeb06e6b234be98c79159dfc0f6d10"
+    , sha256 =
+        "1ry5h5656k2hn3y5s35y7pz0rngbkvj9jc783i4h9ai3hndi00py"
     }
 }

--- a/src/groups/sodiumfrp.dhall
+++ b/src/groups/sodiumfrp.dhall
@@ -5,5 +5,9 @@
         "https://github.com/SodiumFRP/purescript-sodium.git"
     , version =
         "v2.1.0"
+    , rev =
+        "913674e2f30d84c1790bead9c1888ea636176c17"
+    , sha256 =
+        "01v7gz08ls145m4wxd95gk7wiii2crf8mjnhzjyzmph6pgbb77xb"
     }
 }

--- a/src/groups/spacchetti.dhall
+++ b/src/groups/spacchetti.dhall
@@ -5,5 +5,9 @@
         "https://github.com/spacchetti/purescript-metadata.git"
     , version =
         "v0.13.2"
+    , rev =
+        "fef45c102a29d7f8d5d404705531888af6b05e9d"
+    , sha256 =
+        "1ck7aa13ny3mb0c586dc8shakcg7v2mlj0ixbzpjykj2jzfrdn62"
     }
 }

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -12,5 +12,9 @@
         "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
     , version =
         "v0.7.1"
+    , rev =
+        "929afe6eb9a0857a493e1d8f18357ac3042e1a33"
+    , sha256 =
+        "1a6w2wmk550p1gsvdbil7khy9sp030gdx3g299qn63c13480939c"
     }
 }

--- a/src/groups/thimoteus.dhall
+++ b/src/groups/thimoteus.dhall
@@ -5,6 +5,10 @@
         "https://github.com/Thimoteus/purescript-mmorph.git"
     , version =
         "v5.1.0"
+    , rev =
+        "e067ee63c9c08e67b632a8b55930f744ddfad980"
+    , sha256 =
+        "1lvdclqi9wzs4j8xj8ygnj2b87hhpbnl0c6m28zac05rz87s09mg"
     }
 , promises =
     { dependencies =
@@ -19,5 +23,9 @@
         "https://github.com/thimoteus/purescript-promises.git"
     , version =
         "v3.1.1"
+    , rev =
+        "76aac1f6583c39a3745f862636d16c7292d29690"
+    , sha256 =
+        "17vc9ambjad1sjlkv72d5zrhq3m1m5wix2fkqflbbfwabk5qisvz"
     }
 }

--- a/src/groups/truqu.dhall
+++ b/src/groups/truqu.dhall
@@ -5,5 +5,9 @@
         "https://github.com/truqu/purescript-read.git"
     , version =
         "v1.0.1"
+    , rev =
+        "b3969a2091fea50c57ed806820e3d725c8ef8992"
+    , sha256 =
+        "0q8c1xbwh781c1jngy04lbbaq44idy33klq7q1j5ax4vzgd54z0f"
     }
 }

--- a/src/groups/zaquest.dhall
+++ b/src/groups/zaquest.dhall
@@ -5,5 +5,9 @@
         "https://github.com/zaquest/purescript-uint.git"
     , version =
         "v5.1.1"
+    , rev =
+        "9d89e0e4fe231a1ac8466b70a7c2315ce11a6dd7"
+    , sha256 =
+        "13103kqj2abiy8p7v81w1dj8jm0mll177mfjb7ar6km0bsxjigc6"
     }
 }


### PR DESCRIPTION
This is a first step in adding more integrity checks to the git-based tooling (namely `psc-package` and `spago`).

Specifically I'd like to move everything towards:

1. Using git revisions rather than tags
2. Verifying repo contents via a checksum
3. And maybe also providing a checksum for the package sets themselves (too paranoid?)

Hence, this PR adds `rev` and `sha256` fields to the existing package definitions. 

See #32 for discussion.