### PR TITLE
Update react-basic-hooks to v1.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2255,7 +2255,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v0.7.1"
+    "version": "v1.0.1"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -11,6 +11,6 @@
     , repo =
         "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
     , version =
-        "v0.7.1"
+        "v1.0.1"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v1.0.1