### PR TITLE
Update indexed-monad to v1.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1293,7 +1293,7 @@
       "newtype"
     ],
     "repo": "https://github.com/garyb/purescript-indexed-monad.git",
-    "version": "v1.0.0"
+    "version": "v1.1.0"
   },
   "integers": {
     "dependencies": [

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -12,7 +12,7 @@
     , repo =
         "https://github.com/garyb/purescript-indexed-monad.git"
     , version =
-        "v1.0.0"
+        "v1.1.0"
     }
 , quickcheck-laws =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/garyb/purescript-indexed-monad/releases/tag/v1.1.0