### PR TITLE
Update milkis to v7.2.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1521,7 +1521,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-milkis.git",
-    "version": "v7.2.0"
+    "version": "v7.2.1"
   },
   "minibench": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -89,7 +89,7 @@
     , repo =
         "https://github.com/justinwoo/purescript-milkis.git"
     , version =
-        "v7.2.0"
+        "v7.2.1"
     }
 , motsunabe =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-milkis/releases/tag/v7.2.1