### PR TITLE
Update react-basic-hooks to v2.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2334,7 +2334,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v1.0.1"
+    "version": "v2.0.1"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -11,7 +11,7 @@
     , repo =
         "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
     , version =
-        "v1.0.1"
+        "v2.0.1"
     }
 , uuid =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v2.0.1