### PR TITLE
Update form-urlencoded to v5.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -885,7 +885,7 @@
       "tuples"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-form-urlencoded.git",
-    "version": "v4.0.1"
+    "version": "v5.0.0"
   },
   "format": {
     "dependencies": [

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -87,7 +87,7 @@
     , repo =
         "https://github.com/purescript-contrib/purescript-form-urlencoded.git"
     , version =
-        "v4.0.1"
+        "v5.0.0"
     }
 , freet =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-contrib/purescript-form-urlencoded/releases/tag/v5.0.0