### PR TITLE
Update dom-filereader to v5.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -629,7 +629,7 @@
       "web-html"
     ],
     "repo": "https://github.com/nwolverson/purescript-dom-filereader.git",
-    "version": "v4.0.0"
+    "version": "v5.0.0"
   },
   "dom-indexed": {
     "dependencies": [

--- a/src/groups/nwolverson.dhall
+++ b/src/groups/nwolverson.dhall
@@ -12,7 +12,7 @@
     , repo =
         "https://github.com/nwolverson/purescript-dom-filereader.git"
     , version =
-        "v4.0.0"
+        "v5.0.0"
     }
 , suggest =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/nwolverson/purescript-dom-filereader/releases/tag/v5.0.0