### PR TITLE
Update bucketchain-history-api-fallback to v0.3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -334,7 +334,7 @@
       "bucketchain"
     ],
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-history-api-fallback.git",
-    "version": "v0.2.0"
+    "version": "v0.3.0"
   },
   "bucketchain-logger": {
     "dependencies": [

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -60,7 +60,7 @@
     , repo =
         "https://github.com/Bucketchain/purescript-bucketchain-history-api-fallback.git"
     , version =
-        "v0.2.0"
+        "v0.3.0"
     }
 , bucketchain-logger =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Bucketchain/purescript-bucketchain-history-api-fallback/releases/tag/v0.3.0