### PR TITLE
Update web-dom to v3.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3264,7 +3264,7 @@
       "web-events"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-dom.git",
-    "version": "v3.0.0"
+    "version": "v3.1.0"
   },
   "web-events": {
     "dependencies": [

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -20,7 +20,7 @@
     , repo =
         "https://github.com/purescript-web/purescript-web-dom.git"
     , version =
-        "v3.0.0"
+        "v3.1.0"
     }
 , web-events =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-web/purescript-web-dom/releases/tag/v3.1.0