### PR TITLE
Update toppokki to v2.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3026,7 +3026,7 @@
       "record"
     ],
     "repo": "https://github.com/justinwoo/purescript-toppokki.git",
-    "version": "v1.1.0"
+    "version": "v2.0.0"
   },
   "tortellini": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -217,7 +217,7 @@
     , repo =
         "https://github.com/justinwoo/purescript-toppokki.git"
     , version =
-        "v1.1.0"
+        "v2.0.0"
     }
 , tortellini =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-toppokki/releases/tag/v2.0.0