### PR TITLE
Update web-html to v2.2.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3292,7 +3292,7 @@
       "web-storage"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-html.git",
-    "version": "v2.2.1"
+    "version": "v2.2.2"
   },
   "web-socket": {
     "dependencies": [

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -44,7 +44,7 @@
     , repo =
         "https://github.com/purescript-web/purescript-web-html.git"
     , version =
-        "v2.2.1"
+        "v2.2.2"
     }
 , web-socket =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-web/purescript-web-html/releases/tag/v2.2.2