### PR TITLE
Update web-xhr to v3.0.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3333,7 +3333,7 @@
       "web-file"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-xhr.git",
-    "version": "v3.0.1"
+    "version": "v3.0.2"
   },
   "xiaomian": {
     "dependencies": [

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -89,6 +89,6 @@
     , repo =
         "https://github.com/purescript-web/purescript-web-xhr.git"
     , version =
-        "v3.0.1"
+        "v3.0.2"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-web/purescript-web-xhr/releases/tag/v3.0.2