### PR TITLE
Update bucketchain-simple-api to v0.5.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -360,7 +360,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git",
-    "version": "v0.5.0"
+    "version": "v0.5.1"
   },
   "bucketchain-sslify": {
     "dependencies": [

--- a/src/groups/awakesecurity.dhall
+++ b/src/groups/awakesecurity.dhall
@@ -1,5 +1,5 @@
 { precise-datetime =
-    { dependencies = 
+    { dependencies =
         [ "arrays"
         , "console"
         , "datetime"

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -84,7 +84,7 @@
     , repo =
         "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git"
     , version =
-        "v0.5.0"
+        "v0.5.1"
     }
 , bucketchain-sslify =
     { dependencies =

--- a/src/groups/citizennet.dhall
+++ b/src/groups/citizennet.dhall
@@ -17,7 +17,7 @@
         "v0.2.1"
     }
 , halogen-select =
-    { dependencies = 
+    { dependencies =
         [ "halogen", "record" ]
     , repo =
         "https://github.com/citizennet/purescript-halogen-select.git"

--- a/src/groups/matthew-hilty.dhall
+++ b/src/groups/matthew-hilty.dhall
@@ -16,12 +16,8 @@
         "v0.2.0"
     }
 , proxying =
-    { dependencies = 
-        [ "effect"
-        , "generics-rep"
-        , "prelude"
-        , "typelevel-prelude"
-        ]
+    { dependencies =
+        [ "effect", "generics-rep", "prelude", "typelevel-prelude" ]
     , repo =
         "https://github.com/matthew-hilty/purescript-proxying.git"
     , version =
@@ -45,12 +41,7 @@
     }
 , subcategory =
     { dependencies =
-        [ "prelude"
-        , "profunctor"
-        , "record"
-        , "proxy"
-        , "typelevel-prelude"
-        ]
+        [ "prelude", "profunctor", "record", "proxy", "typelevel-prelude" ]
     , repo =
         "https://github.com/matthew-hilty/purescript-subcategory.git"
     , version =

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -1,6 +1,11 @@
 { halogen-formless =
     { dependencies =
-        [ "halogen", "variant", "heterogeneous", "generics-rep", "profunctor-lenses" ]
+        [ "halogen"
+        , "variant"
+        , "heterogeneous"
+        , "generics-rep"
+        , "profunctor-lenses"
+        ]
     , repo =
         "https://github.com/thomashoneyman/purescript-halogen-formless.git"
     , version =
@@ -8,7 +13,13 @@
     }
 , slug =
     { dependencies =
-        [ "prelude", "maybe", "strings", "unicode", "generics-rep", "argonaut-codecs" ]
+        [ "prelude"
+        , "maybe"
+        , "strings"
+        , "unicode"
+        , "generics-rep"
+        , "argonaut-codecs"
+        ]
     , repo =
         "https://github.com/thomashoneyman/purescript-slug.git"
     , version =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Bucketchain/purescript-bucketchain-simple-api/releases/tag/v0.5.1