### PR TITLE
Update bower-json to v1.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -270,7 +270,7 @@
       "tuples"
     ],
     "repo": "https://github.com/klntsky/purescript-bower-json.git",
-    "version": "v0.1.0"
+    "version": "v1.0.0"
   },
   "bucketchain": {
     "dependencies": [

--- a/src/groups/klntsky.dhall
+++ b/src/groups/klntsky.dhall
@@ -46,6 +46,6 @@
     , repo =
         "https://github.com/klntsky/purescript-bower-json.git"
     , version =
-        "v0.1.0"
+        "v1.0.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/klntsky/purescript-bower-json/releases/tag/v1.0.0