### PR TITLE
Update safely to v4.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2629,7 +2629,7 @@
       "lists"
     ],
     "repo": "https://github.com/paf31/purescript-safely.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "search-trie": {
     "dependencies": [

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -94,7 +94,7 @@
     , repo =
         "https://github.com/paf31/purescript-safely.git"
     , version =
-        "v4.0.0"
+        "v4.0.1"
     }
 , string-parsers =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/paf31/purescript-safely/releases/tag/v4.0.1