### PR TITLE
Update freedom to v1.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -974,7 +974,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom.git",
-    "version": "v1.1.2"
+    "version": "v1.2.0"
   },
   "freedom-now": {
     "dependencies": [

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -11,7 +11,7 @@
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom.git"
     , version =
-        "v1.1.2"
+        "v1.2.0"
     }
 , freedom-now =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-freedom/purescript-freedom/releases/tag/v1.2.0