### PR TITLE
Update profunctor to v4.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2185,7 +2185,7 @@
       "tuples"
     ],
     "repo": "https://github.com/purescript/purescript-profunctor.git",
-    "version": "v4.0.0"
+    "version": "v4.1.0"
   },
   "profunctor-lenses": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -499,7 +499,7 @@
     , repo =
         "https://github.com/purescript/purescript-profunctor.git"
     , version =
-        "v4.0.0"
+        "v4.1.0"
     }
 , proxy =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript/purescript-profunctor/releases/tag/v4.1.0