### PR TITLE
Update tailrec to v4.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3092,7 +3092,7 @@
       "refs"
     ],
     "repo": "https://github.com/purescript/purescript-tailrec.git",
-    "version": "v4.0.0"
+    "version": "v4.1.0"
   },
   "test-unit": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -631,7 +631,7 @@
     , repo =
         "https://github.com/purescript/purescript-tailrec.git"
     , version =
-        "v4.0.0"
+        "v4.1.0"
     }
 , transformers =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript/purescript-tailrec/releases/tag/v4.1.0