### PR TITLE
Update freedom-now to v2.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -982,7 +982,7 @@
       "js-timers"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-now.git",
-    "version": "v1.0.0"
+    "version": "v2.0.0"
   },
   "freedom-portal": {
     "dependencies": [

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -19,7 +19,7 @@
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-now.git"
     , version =
-        "v1.0.0"
+        "v2.0.0"
     }
 , freedom-portal =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-freedom/purescript-freedom-now/releases/tag/v2.0.0