### PR TITLE
Update argonaut-core to v5.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -104,7 +104,7 @@
       "tailrec"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-argonaut-core.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "argonaut-generic": {
     "dependencies": [

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -47,7 +47,7 @@
     , repo =
         "https://github.com/purescript-contrib/purescript-argonaut-core.git"
     , version =
-        "v5.0.0"
+        "v5.0.1"
     }
 , argonaut-generic =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-contrib/purescript-argonaut-core/releases/tag/v5.0.1