### PR TITLE
Update identy to v2.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1342,7 +1342,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-identy.git",
-    "version": "v2.0.2"
+    "version": "v2.1.0"
   },
   "indexed-monad": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -20,7 +20,7 @@
     , repo =
         "https://github.com/oreshinya/purescript-identy.git"
     , version =
-        "v2.0.2"
+        "v2.1.0"
     }
 , mysql =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-identy/releases/tag/v2.1.0