### PR TITLE
Update behaviors to v8.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -237,7 +237,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/paf31/purescript-behaviors.git",
-    "version": "v7.0.0"
+    "version": "v8.0.0"
   },
   "bifunctors": {
     "dependencies": [

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -13,7 +13,7 @@
     , repo =
         "https://github.com/paf31/purescript-behaviors.git"
     , version =
-        "v7.0.0"
+        "v8.0.0"
     }
 , event =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/paf31/purescript-behaviors/releases/tag/v8.0.0