### PR TITLE
Update event to v1.3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -735,7 +735,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/paf31/purescript-event.git",
-    "version": "v1.2.4"
+    "version": "v1.3.0"
   },
   "exceptions": {
     "dependencies": [

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -29,7 +29,7 @@
     , repo =
         "https://github.com/paf31/purescript-event.git"
     , version =
-        "v1.2.4"
+        "v1.3.0"
     }
 , folds =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/paf31/purescript-event/releases/tag/v1.3.0