### PR TITLE
Update typelevel to v6.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3258,7 +3258,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/bodil/purescript-typelevel.git",
-    "version": "v5.0.0"
+    "version": "v6.0.0"
   },
   "typelevel-prelude": {
     "dependencies": [

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -61,6 +61,6 @@
     , repo =
         "https://github.com/bodil/purescript-typelevel.git"
     , version =
-        "v5.0.0"
+        "v6.0.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/bodil/purescript-typelevel/releases/tag/v6.0.0