### PR TITLE
Update coroutines to v5.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -513,7 +513,7 @@
       "profunctor"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-coroutines.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "crypto": {
     "dependencies": [

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -79,7 +79,7 @@
     , repo =
         "https://github.com/purescript-contrib/purescript-coroutines.git"
     , version =
-        "v5.0.0"
+        "v5.0.1"
     }
 , form-urlencoded =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-contrib/purescript-coroutines/releases/tag/v5.0.1