### PR TITLE
Update spec to v4.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2848,7 +2848,7 @@
       "transformers"
     ],
     "repo": "https://github.com/purescript-spec/purescript-spec.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "spec-discovery": {
     "dependencies": [

--- a/src/groups/purescript-spec.dhall
+++ b/src/groups/purescript-spec.dhall
@@ -17,6 +17,6 @@
     , repo =
         "https://github.com/purescript-spec/purescript-spec.git"
     , version =
-        "v4.0.0"
+        "v4.0.1"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-spec/purescript-spec/releases/tag/v4.0.1