### PR TITLE
Update aff to v5.1.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10,7 +10,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/slamdata/purescript-aff.git",
-    "version": "v5.1.1"
+    "version": "v5.1.2"
   },
   "aff-bus": {
     "dependencies": [

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -11,7 +11,7 @@
     , repo =
         "https://github.com/slamdata/purescript-aff.git"
     , version =
-        "v5.1.1"
+        "v5.1.2"
     }
 , aff-bus =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/slamdata/purescript-aff/releases/tag/v5.1.2