### PR TITLE
Update mysql to v3.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1686,7 +1686,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-mysql.git",
-    "version": "v3.0.1"
+    "version": "v3.1.0"
   },
   "naporitan": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -28,7 +28,7 @@
     , repo =
         "https://github.com/oreshinya/purescript-mysql.git"
     , version =
-        "v3.0.1"
+        "v3.1.0"
     }
 , nodemailer =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-mysql/releases/tag/v3.1.0