### PR TITLE
Update web-file to v2.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3458,7 +3458,7 @@
       "web-dom"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-file.git",
-    "version": "v2.1.2"
+    "version": "v2.2.0"
   },
   "web-html": {
     "dependencies": [

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -36,7 +36,7 @@
     , repo =
         "https://github.com/purescript-web/purescript-web-file.git"
     , version =
-        "v2.1.2"
+        "v2.2.0"
     }
 , web-html =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-web/purescript-web-file/releases/tag/v2.2.0