### PR TITLE
Update monad-logger to v1.3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1689,7 +1689,7 @@
       "tuples"
     ],
     "repo": "https://github.com/cprussin/purescript-monad-logger.git",
-    "version": "v1.2.0"
+    "version": "v1.3.0"
   },
   "monad-loops": {
     "dependencies": [

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -60,7 +60,7 @@
     , repo =
         "https://github.com/cprussin/purescript-monad-logger.git"
     , version =
-        "v1.2.0"
+        "v1.3.0"
     }
 , node-electron =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/cprussin/purescript-monad-logger/releases/tag/v1.3.0