### PR TITLE
Update bucketchain-simple-api to v1.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -381,7 +381,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git",
-    "version": "v0.5.1"
+    "version": "v1.0.0"
   },
   "bucketchain-sslify": {
     "dependencies": [

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -84,7 +84,7 @@
     , repo =
         "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git"
     , version =
-        "v0.5.1"
+        "v1.0.0"
     }
 , bucketchain-sslify =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Bucketchain/purescript-bucketchain-simple-api/releases/tag/v1.0.0