### PR TITLE
Update record-extra to v3.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2562,7 +2562,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-record-extra.git",
-    "version": "v3.0.0"
+    "version": "v3.0.1"
   },
   "record-format": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -137,7 +137,7 @@
     , repo =
         "https://github.com/justinwoo/purescript-record-extra.git"
     , version =
-        "v3.0.0"
+        "v3.0.1"
     }
 , redux-devtools =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/justinwoo/purescript-record-extra/releases/tag/v3.0.1