### PR TITLE
Update httpure to v0.9.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1329,7 +1329,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/cprussin/purescript-httpure.git",
-    "version": "v0.8.3"
+    "version": "v0.9.0"
   },
   "httpure-contrib-biscotti": {
     "dependencies": [

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -34,7 +34,7 @@
     , repo =
         "https://github.com/cprussin/purescript-httpure.git"
     , version =
-        "v0.8.3"
+        "v0.9.0"
     }
 , monad-logger =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/cprussin/purescript-httpure/releases/tag/v0.9.0