### PR TITLE
Add .git ending to unsafe-reference repo link

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3425,7 +3425,7 @@
   },
   "unsafe-reference": {
     "dependencies": [],
-    "repo": "https://github.com/purescript-contrib/purescript-unsafe-reference",
+    "repo": "https://github.com/purescript-contrib/purescript-unsafe-reference.git",
     "version": "v3.0.1"
   },
   "uri": {


### PR DESCRIPTION
Make unsafe-reference be used with spago

[Issue-499](https://github.com/purescript/package-sets/issues/499)
