### PR TITLE
Migrate packages to purescript-hyper group.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1357,6 +1357,7 @@
       "argonaut",
       "arrays",
       "avar",
+      "console",
       "control",
       "effect",
       "foldable-traversable",
@@ -1368,17 +1369,14 @@
       "node-http",
       "ordered-collections",
       "proxy",
-      "psci-support",
       "random",
       "record-extra",
       "smolder",
-      "spec",
-      "spec-discovery",
       "strings",
       "transformers",
       "typelevel-prelude"
     ],
-    "repo": "https://github.com/owickstrom/hyper.git",
+    "repo": "https://github.com/purescript-hyper/hyper.git",
     "version": "v0.11.0"
   },
   "hypertrout": {
@@ -1387,12 +1385,9 @@
       "console",
       "hyper",
       "prelude",
-      "psci-support",
-      "spec",
-      "spec-discovery",
       "trout"
     ],
-    "repo": "https://github.com/owickstrom/purescript-hypertrout.git",
+    "repo": "https://github.com/purescript-hyper/purescript-hypertrout.git",
     "version": "v0.11.0"
   },
   "identity": {
@@ -3300,12 +3295,10 @@
       "media-types",
       "prelude",
       "smolder",
-      "spec",
-      "spec-discovery",
       "uri"
     ],
-    "repo": "https://github.com/owickstrom/purescript-trout.git",
-    "version": "v0.12.0"
+    "repo": "https://github.com/purescript-hyper/purescript-trout.git",
+    "version": "v0.12.1"
   },
   "tuples": {
     "dependencies": [

--- a/src/groups/owickstrom.dhall
+++ b/src/groups/owickstrom.dhall
@@ -1,52 +1,4 @@
-{ hyper =
-    { dependencies =
-        [ "aff"
-        , "avar"
-        , "argonaut"
-        , "arrays"
-        , "control"
-        , "effect"
-        , "foldable-traversable"
-        , "generics-rep"
-        , "http-methods"
-        , "indexed-monad"
-        , "media-types"
-        , "node-fs-aff"
-        , "node-http"
-        , "ordered-collections"
-        , "proxy"
-        , "psci-support"
-        , "random"
-        , "smolder"
-        , "spec"
-        , "spec-discovery"
-        , "strings"
-        , "transformers"
-        , "record-extra"
-        , "typelevel-prelude"
-        ]
-    , repo =
-        "https://github.com/owickstrom/hyper.git"
-    , version =
-        "v0.11.0"
-    }
-, hypertrout =
-    { dependencies =
-        [ "argonaut-generic"
-        , "console"
-        , "hyper"
-        , "prelude"
-        , "psci-support"
-        , "spec"
-        , "spec-discovery"
-        , "trout"
-        ]
-    , repo =
-        "https://github.com/owickstrom/purescript-hypertrout.git"
-    , version =
-        "v0.11.0"
-    }
-, spec-discovery =
+{ spec-discovery =
     { dependencies =
         [ "arrays", "effect", "node-fs", "prelude", "spec" ]
     , repo =
@@ -61,20 +13,5 @@
         "https://github.com/owickstrom/purescript-spec-quickcheck.git"
     , version =
         "v3.1.0"
-    }
-, trout =
-    { dependencies =
-        [ "argonaut"
-        , "media-types"
-        , "prelude"
-        , "smolder"
-        , "spec"
-        , "spec-discovery"
-        , "uri"
-        ]
-    , repo =
-        "https://github.com/owickstrom/purescript-trout.git"
-    , version =
-        "v0.12.0"
     }
 }

--- a/src/groups/purescript-hyper.dhall
+++ b/src/groups/purescript-hyper.dhall
@@ -1,0 +1,47 @@
+{ hyper =
+    { dependencies =
+        [ "aff"
+        , "avar"
+        , "argonaut"
+        , "arrays"
+        , "console"
+        , "control"
+        , "effect"
+        , "foldable-traversable"
+        , "generics-rep"
+        , "http-methods"
+        , "indexed-monad"
+        , "media-types"
+        , "node-fs-aff"
+        , "node-http"
+        , "ordered-collections"
+        , "proxy"
+        , "random"
+        , "smolder"
+        , "strings"
+        , "transformers"
+        , "record-extra"
+        , "typelevel-prelude"
+        ]
+    , repo =
+        "https://github.com/purescript-hyper/hyper.git"
+    , version =
+        "v0.11.0"
+    }
+, hypertrout =
+    { dependencies =
+        [ "argonaut-generic", "console", "hyper", "prelude", "trout" ]
+    , repo =
+        "https://github.com/purescript-hyper/purescript-hypertrout.git"
+    , version =
+        "v0.11.0"
+    }
+, trout =
+    { dependencies =
+        [ "argonaut", "media-types", "prelude", "smolder", "uri" ]
+    , repo =
+        "https://github.com/purescript-hyper/purescript-trout.git"
+    , version =
+        "v0.12.1"
+    }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -57,6 +57,7 @@ let packages =
       ⫽ ./groups/paluh.dhall
       ⫽ ./groups/passy.dhall
       ⫽ ./groups/purescript-freedom.dhall
+      ⫽ ./groups/purescript-hyper.dhall
       ⫽ ./groups/purescript-spec.dhall
       ⫽ ./groups/reactormonk.dhall
       ⫽ ./groups/rightfold.dhall


### PR DESCRIPTION
@owickstrom recently moved the `trout`, `hyper`, and `hypertrout` repositories to a new organization as you can see by these redirects:

https://github.com/owickstrom/purescript-trout
https://github.com/owickstrom/hyper
https://github.com/owickstrom/purescript-hypertrout

I have moved these packages to the purescript-hyper group accordingly. I also removed some redundant dependencies (psci-support, etc.) in the process and updated `trout` to v0.12.1 (backward-compatible).