### PR TITLE
Fix url of unsafe-reference

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3418,7 +3418,7 @@
   },
   "unsafe-reference": {
     "dependencies": [],
-    "repo": "https://github.com/purescript-contrib/purescript-unsafe-reference",
+    "repo": "https://github.com/purescript-contrib/purescript-unsafe-reference.git",
     "version": "v3.0.1"
   },
   "uri": {

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -326,7 +326,7 @@
     { dependencies =
         [] : List Text
     , repo =
-        "https://github.com/purescript-contrib/purescript-unsafe-reference"
+        "https://github.com/purescript-contrib/purescript-unsafe-reference.git"
     , version =
         "v3.0.1"
     }


### PR DESCRIPTION
This is proper fix for https://github.com/purescript/package-sets/issues/499 which supersedes https://github.com/purescript/package-sets/pull/500 in which author fixed the url in package.json, but not in the dhall config.