### PR TITLE
Update bytestrings to v8.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -415,7 +415,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/rightfold/purescript-bytestrings.git",
-    "version": "v7.0.0"
+    "version": "v8.0.0"
   },
   "canvas": {
     "dependencies": [

--- a/src/groups/rightfold.dhall
+++ b/src/groups/rightfold.dhall
@@ -17,7 +17,7 @@
     , repo =
         "https://github.com/rightfold/purescript-bytestrings.git"
     , version =
-        "v7.0.0"
+        "v8.0.0"
     }
 , quotient =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/rightfold/purescript-bytestrings/releases/tag/v8.0.0