### PR TITLE
Update querydsl to v0.10.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2373,7 +2373,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/Dretch/purescript-querydsl.git",
-    "version": "v0.10.0"
+    "version": "v0.10.1"
   },
   "quickcheck": {
     "dependencies": [

--- a/src/groups/dretch.dhall
+++ b/src/groups/dretch.dhall
@@ -19,6 +19,6 @@
     , repo =
         "https://github.com/Dretch/purescript-querydsl.git"
     , version =
-        "v0.10.0"
+        "v0.10.1"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Dretch/purescript-querydsl/releases/tag/v0.10.1