### PR TITLE
Update arraybuffer to v10.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -136,7 +136,7 @@
       "uint"
     ],
     "repo": "https://github.com/jacereda/purescript-arraybuffer.git",
-    "version": "v10.0.0"
+    "version": "v10.0.1"
   },
   "arraybuffer-types": {
     "dependencies": [],

--- a/src/groups/jacereda.dhall
+++ b/src/groups/jacereda.dhall
@@ -14,6 +14,6 @@
     , repo =
         "https://github.com/jacereda/purescript-arraybuffer.git"
     , version =
-        "v10.0.0"
+        "v10.0.1"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/jacereda/purescript-arraybuffer/releases/tag/v10.0.1