### PR TITLE
Update mysql to v4.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1747,7 +1747,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-mysql.git",
-    "version": "v3.4.1"
+    "version": "v4.0.0"
   },
   "naporitan": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -28,7 +28,7 @@
     , repo =
         "https://github.com/oreshinya/purescript-mysql.git"
     , version =
-        "v3.4.1"
+        "v4.0.0"
     }
 , nodemailer =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-mysql/releases/tag/v4.0.0