### PR TITLE
Update simple-timestamp to v2.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2873,7 +2873,7 @@
       "spec"
     ],
     "repo": "https://github.com/reactormonk/purescript-simple-timestamp.git",
-    "version": "v1.3.0"
+    "version": "v2.0.0"
   },
   "sized-vectors": {
     "dependencies": [

--- a/src/groups/reactormonk.dhall
+++ b/src/groups/reactormonk.dhall
@@ -29,6 +29,6 @@
     , repo =
         "https://github.com/reactormonk/purescript-simple-timestamp.git"
     , version =
-        "v1.3.0"
+        "v2.0.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/reactormonk/purescript-simple-timestamp/releases/tag/v2.0.0