### PR TITLE
Update simple-jwt to v2.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2858,7 +2858,7 @@
       "strings"
     ],
     "repo": "https://github.com/oreshinya/purescript-simple-jwt.git",
-    "version": "v1.1.1"
+    "version": "v2.0.0"
   },
   "simple-timestamp": {
     "dependencies": [

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -60,6 +60,6 @@
     , repo =
         "https://github.com/oreshinya/purescript-simple-jwt.git"
     , version =
-        "v1.1.1"
+        "v2.0.0"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/oreshinya/purescript-simple-jwt/releases/tag/v2.0.0