### PR TITLE
Fix URL of purescript-spork

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2997,7 +2997,7 @@
       "web-html",
       "web-uievents"
     ],
-    "repo": "https://github.com/natefaubion/purescript-spork",
+    "repo": "https://github.com/natefaubion/purescript-spork.git",
     "version": "v1.0.0"
   },
   "st": {

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -108,7 +108,7 @@
         , "ordered-collections"
         ]
     , repo =
-        "https://github.com/natefaubion/purescript-spork"
+        "https://github.com/natefaubion/purescript-spork.git"
     , version =
         "v1.0.0"
     }


### PR DESCRIPTION
Spago gives warning and refuses to cache this repo locally, because the URL doesn't have the required form. While I was at it I checked all the urls in the package set and all the others have the correct form.