### PR TITLE
Update bucketchain-header-utils to v0.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -341,7 +341,7 @@
       "bucketchain"
     ],
     "repo": "https://github.com/Bucketchain/purescript-bucketchain-header-utils.git",
-    "version": "v0.1.0"
+    "version": "v0.2.0"
   },
   "bucketchain-health": {
     "dependencies": [

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -44,7 +44,7 @@
     , repo =
         "https://github.com/Bucketchain/purescript-bucketchain-header-utils.git"
     , version =
-        "v0.1.0"
+        "v0.2.0"
     }
 , bucketchain-health =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/Bucketchain/purescript-bucketchain-header-utils/releases/tag/v0.2.0