### PR TITLE
Update arrays to v5.3.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -159,7 +159,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-arrays.git",
-    "version": "v5.3.0"
+    "version": "v5.3.1"
   },
   "assert": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -16,7 +16,7 @@
     , repo =
         "https://github.com/purescript/purescript-arrays.git"
     , version =
-        "v5.3.0"
+        "v5.3.1"
     }
 , assert =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript/purescript-arrays/releases/tag/v5.3.1