### PR TITLE
Update freedom to v1.4.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1023,7 +1023,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom.git",
-    "version": "v1.3.0"
+    "version": "v1.4.0"
   },
   "freedom-now": {
     "dependencies": [

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -11,7 +11,7 @@
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom.git"
     , version =
-        "v1.3.0"
+        "v1.4.0"
     }
 , freedom-now =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/purescript-freedom/purescript-freedom/releases/tag/v1.4.0