### PR TITLE
Update sized-vectors to v4.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2886,7 +2886,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/bodil/purescript-sized-vectors.git",
-    "version": "v3.1.0"
+    "version": "v4.0.0"
   },
   "slug": {
     "dependencies": [

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -19,7 +19,7 @@
     , repo =
         "https://github.com/bodil/purescript-sized-vectors.git"
     , version =
-        "v3.1.0"
+        "v4.0.0"
     }
 , smolder =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/bodil/purescript-sized-vectors/releases/tag/v4.0.0