### PR TITLE
Update smolder to v12.3.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2912,7 +2912,7 @@
       "tuples"
     ],
     "repo": "https://github.com/bodil/purescript-smolder.git",
-    "version": "v12.2.0"
+    "version": "v12.3.0"
   },
   "snabbdom": {
     "dependencies": [

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -35,7 +35,7 @@
     , repo =
         "https://github.com/bodil/purescript-smolder.git"
     , version =
-        "v12.2.0"
+        "v12.3.0"
     }
 , test-unit =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/bodil/purescript-smolder/releases/tag/v12.3.0