### PR TITLE
Update string-parsers to v5.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3023,7 +3023,7 @@
       "tailrec"
     ],
     "repo": "https://github.com/paf31/purescript-string-parsers.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "strings": {
     "dependencies": [

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -120,7 +120,7 @@
     , repo =
         "https://github.com/paf31/purescript-string-parsers.git"
     , version =
-        "v5.0.0"
+        "v5.0.1"
     }
 , yargs =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/paf31/purescript-string-parsers/releases/tag/v5.0.1