### PR TITLE
Update encoding to v0.0.6

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -727,7 +727,7 @@
       "prelude"
     ],
     "repo": "https://github.com/menelaos/purescript-encoding.git",
-    "version": "v0.0.5"
+    "version": "v0.0.6"
   },
   "enums": {
     "dependencies": [

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -21,7 +21,7 @@
     , repo =
         "https://github.com/menelaos/purescript-encoding.git"
     , version =
-        "v0.0.5"
+        "v0.0.6"
     }
 , jwt =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/menelaos/purescript-encoding/releases/tag/v0.0.6