### PR TITLE
Update stringutils to v0.0.10

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3072,7 +3072,7 @@
       "strings"
     ],
     "repo": "https://github.com/menelaos/purescript-stringutils.git",
-    "version": "v0.0.9"
+    "version": "v0.0.10"
   },
   "strongcheck": {
     "dependencies": [

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -53,6 +53,6 @@
     , repo =
         "https://github.com/menelaos/purescript-stringutils.git"
     , version =
-        "v0.0.9"
+        "v0.0.10"
     }
 }


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/menelaos/purescript-stringutils/releases/tag/v0.0.10