### PR TITLE
Update b64 to v0.0.6

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -195,7 +195,7 @@
       "strings"
     ],
     "repo": "https://github.com/menelaos/purescript-b64.git",
-    "version": "v0.0.5"
+    "version": "v0.0.6"
   },
   "basic-auth": {
     "dependencies": [

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -13,7 +13,7 @@
     , repo =
         "https://github.com/menelaos/purescript-b64.git"
     , version =
-        "v0.0.5"
+        "v0.0.6"
     }
 , encoding =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/menelaos/purescript-b64/releases/tag/v0.0.6