### PR TITLE
Update jwt to v0.0.7

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1492,7 +1492,7 @@
       "strings"
     ],
     "repo": "https://github.com/menelaos/purescript-jwt.git",
-    "version": "v0.0.6"
+    "version": "v0.0.7"
   },
   "kancho": {
     "dependencies": [

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -38,7 +38,7 @@
     , repo =
         "https://github.com/menelaos/purescript-jwt.git"
     , version =
-        "v0.0.6"
+        "v0.0.7"
     }
 , stringutils =
     { dependencies =


### PR DESCRIPTION
The addition has been verified by running `spago verify-set` in a clean project, so this is safe to merge.

Link to release: https://github.com/menelaos/purescript-jwt/releases/tag/v0.0.7