### PR TITLE
Updates 2019-11-01

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2526,6 +2526,7 @@
       "console",
       "effect",
       "exceptions",
+      "foreign-object",
       "functions",
       "nullable",
       "record",

--- a/packages.json
+++ b/packages.json
@@ -3401,7 +3401,8 @@
     "dependencies": [
       "generics-rep",
       "math",
-      "maybe"
+      "maybe",
+      "quickcheck"
     ],
     "repo": "https://github.com/zaquest/purescript-uint.git",
     "version": "v5.1.2"

--- a/packages.json
+++ b/packages.json
@@ -556,6 +556,7 @@
   },
   "control": {
     "dependencies": [
+      "newtype",
       "prelude"
     ],
     "repo": "https://github.com/purescript/purescript-control.git",

--- a/packages.json
+++ b/packages.json
@@ -151,7 +151,7 @@
       "uint"
     ],
     "repo": "https://github.com/jacereda/purescript-arraybuffer.git",
-    "version": "v10.0.1"
+    "version": "v10.0.2"
   },
   "arraybuffer-types": {
     "dependencies": [],
@@ -559,7 +559,7 @@
       "prelude"
     ],
     "repo": "https://github.com/purescript/purescript-control.git",
-    "version": "v4.1.0"
+    "version": "v4.2.0"
   },
   "coroutines": {
     "dependencies": [
@@ -1046,7 +1046,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom.git",
-    "version": "v1.4.0"
+    "version": "v1.4.1"
   },
   "freedom-now": {
     "dependencies": [
@@ -1077,7 +1077,7 @@
       "js-timers"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-transition.git",
-    "version": "v1.0.0"
+    "version": "v1.0.1"
   },
   "freedom-virtualized": {
     "dependencies": [
@@ -2534,7 +2534,7 @@
       "web-html"
     ],
     "repo": "https://github.com/lumihq/purescript-react-basic.git",
-    "version": "v11.0.0"
+    "version": "v13.0.0"
   },
   "react-basic-hooks": {
     "dependencies": [
@@ -3404,7 +3404,7 @@
       "maybe"
     ],
     "repo": "https://github.com/zaquest/purescript-uint.git",
-    "version": "v5.1.1"
+    "version": "v5.1.2"
   },
   "undefinable": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -474,7 +474,7 @@
       "test-unit"
     ],
     "repo": "https://github.com/icyrockcom/purescript-cheerio.git",
-    "version": "v0.2.0"
+    "version": "v0.2.1"
   },
   "chirashi": {
     "dependencies": [
@@ -3045,7 +3045,7 @@
       "tailrec"
     ],
     "repo": "https://github.com/purescript/purescript-st.git",
-    "version": "v4.0.0"
+    "version": "v4.0.2"
   },
   "string-parsers": {
     "dependencies": [
@@ -3396,7 +3396,7 @@
       "type-equality"
     ],
     "repo": "https://github.com/purescript/purescript-typelevel-prelude.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "uint": {
     "dependencies": [

--- a/src/groups/icyrockcom.dhall
+++ b/src/groups/icyrockcom.dhall
@@ -2,6 +2,6 @@
     { dependencies =
         [ "console", "effect", "functions", "prelude", "test-unit" ]
     , repo = "https://github.com/icyrockcom/purescript-cheerio.git"
-    , version = "v0.2.0"
+    , version = "v0.2.1"
     }
 }

--- a/src/groups/jacereda.dhall
+++ b/src/groups/jacereda.dhall
@@ -12,6 +12,6 @@
         , "uint"
         ]
     , repo = "https://github.com/jacereda/purescript-arraybuffer.git"
-    , version = "v10.0.1"
+    , version = "v10.0.2"
     }
 }

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -13,6 +13,6 @@
         , "web-html"
         ]
     , repo = "https://github.com/lumihq/purescript-react-basic.git"
-    , version = "v11.0.0"
+    , version = "v13.0.0"
     }
 }

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -4,6 +4,7 @@
         , "console"
         , "effect"
         , "exceptions"
+        , "foreign-object"
         , "functions"
         , "nullable"
         , "record"

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -9,7 +9,7 @@
         , "web-html"
         ]
     , repo = "https://github.com/purescript-freedom/purescript-freedom.git"
-    , version = "v1.4.0"
+    , version = "v1.4.1"
     }
 , freedom-now =
     { dependencies = [ "freedom", "js-timers" ]
@@ -33,7 +33,7 @@
         [ "freedom", "js-timers" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-transition.git"
-    , version = "v1.0.0"
+    , version = "v1.0.1"
     }
 , freedom-virtualized =
     { dependencies =

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -467,7 +467,7 @@
 , st =
     { dependencies = [ "partial", "prelude", "tailrec" ]
     , repo = "https://github.com/purescript/purescript-st.git"
-    , version = "v4.0.0"
+    , version = "v4.0.2"
     }
 , strings =
     { dependencies =
@@ -548,7 +548,7 @@
 , typelevel-prelude =
     { dependencies = [ "prelude", "proxy", "type-equality" ]
     , repo = "https://github.com/purescript/purescript-typelevel-prelude.git"
-    , version = "v5.0.0"
+    , version = "v5.0.1"
     }
 , unfoldable =
     { dependencies =

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -61,7 +61,7 @@
     , version = "v4.0.1"
     }
 , control =
-    { dependencies = [ "prelude" ]
+    { dependencies = [ "prelude", "newtype" ]
     , repo = "https://github.com/purescript/purescript-control.git"
     , version = "v4.2.0"
     }

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -63,7 +63,7 @@
 , control =
     { dependencies = [ "prelude" ]
     , repo = "https://github.com/purescript/purescript-control.git"
-    , version = "v4.1.0"
+    , version = "v4.2.0"
     }
 , datetime =
     { dependencies =

--- a/src/groups/zaquest.dhall
+++ b/src/groups/zaquest.dhall
@@ -1,5 +1,5 @@
 { uint =
-    { dependencies = [ "generics-rep", "math", "maybe" ]
+    { dependencies = [ "generics-rep", "math", "maybe", "quickcheck" ]
     , repo = "https://github.com/zaquest/purescript-uint.git"
     , version = "v5.1.2"
     }

--- a/src/groups/zaquest.dhall
+++ b/src/groups/zaquest.dhall
@@ -1,6 +1,6 @@
 { uint =
     { dependencies = [ "generics-rep", "math", "maybe" ]
     , repo = "https://github.com/zaquest/purescript-uint.git"
-    , version = "v5.1.1"
+    , version = "v5.1.2"
     }
 }


### PR DESCRIPTION
Updated packages:
- [`arraybuffer` upgraded to `v10.0.2`](https://github.com/jacereda/purescript-arraybuffer/releases/tag/v10.0.2)
- [`cheerio` upgraded to `v0.2.1`](https://github.com/icyrockcom/purescript-cheerio/releases/tag/v0.2.1)
- [`control` upgraded to `v4.2.0`](https://github.com/purescript/purescript-control/releases/tag/v4.2.0)
- [`react-basic` upgraded to `v13.0.0`](https://github.com/lumihq/purescript-react-basic/releases/tag/v13.0.0)
- [`st` upgraded to `v4.0.2`](https://github.com/purescript/purescript-st/releases/tag/v4.0.2)
- [`typelevel-prelude` upgraded to `v5.0.1`](https://github.com/purescript/purescript-typelevel-prelude/releases/tag/v5.0.1)
- [`uint` upgraded to `v5.1.2`](https://github.com/zaquest/purescript-uint/releases/tag/v5.1.2)
