### PR TITLE
Updates 2019-11-07

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2568,7 +2568,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v3.0.0"
+    "version": "v4.0.0"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -9,7 +9,7 @@
         , "unsafe-reference"
         ]
     , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-    , version = "v3.0.0"
+    , version = "v4.0.0"
     }
 , uuid =
     { dependencies = [ "effect", "maybe" ]


### PR DESCRIPTION
Updated packages:
- [`react-basic-hooks` upgraded to `v4.0.0`](https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v4.0.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
