### PR TITLE
Updates 2019-11-09

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3356,7 +3356,7 @@
       "uri"
     ],
     "repo": "https://github.com/purescript-hyper/purescript-trout.git",
-    "version": "v0.12.1"
+    "version": "v0.12.2"
   },
   "tuples": {
     "dependencies": [

--- a/src/groups/purescript-hyper.dhall
+++ b/src/groups/purescript-hyper.dhall
@@ -35,6 +35,6 @@
 , trout =
     { dependencies = [ "argonaut", "media-types", "prelude", "smolder", "uri" ]
     , repo = "https://github.com/purescript-hyper/purescript-trout.git"
-    , version = "v0.12.1"
+    , version = "v0.12.2"
     }
 }


### PR DESCRIPTION
Updated packages:
- [`trout` upgraded to `v0.12.2`](https://github.com/purescript-hyper/purescript-trout/releases/tag/v0.12.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
