### PR TITLE
Updates 2019-12-04

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1398,7 +1398,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/cprussin/purescript-httpure.git",
-    "version": "v0.9.0"
+    "version": "v0.10.0"
   },
   "httpure-contrib-biscotti": {
     "dependencies": [

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -32,7 +32,7 @@
         , "unsafe-coerce"
         ]
     , repo = "https://github.com/cprussin/purescript-httpure.git"
-    , version = "v0.9.0"
+    , version = "v0.10.0"
     }
 , monad-logger =
     { dependencies =


### PR DESCRIPTION
Updated packages:
- [`httpure` upgraded to `v0.10.0`](https://github.com/cprussin/purescript-httpure/releases/tag/v0.10.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
