### PR TITLE
Updates 2020-01-02

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2605,7 +2605,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v4.0.0"
+    "version": "v4.1.0"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -9,7 +9,7 @@
         , "unsafe-reference"
         ]
     , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-    , version = "v4.0.0"
+    , version = "v4.1.0"
     }
 , uuid =
     { dependencies = [ "effect", "maybe" ]


### PR DESCRIPTION
Updated packages:
- [`react-basic-hooks` upgraded to `v4.1.0`](https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v4.1.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
