### PR TITLE
Add purescript-interpolate

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1535,6 +1535,13 @@
     "repo": "https://github.com/purescript/purescript-integers.git",
     "version": "v4.0.0"
   },
+  "interpolate": {
+    "dependencies": [
+      "prelude"
+    ],
+    "repo": "https://github.com/jordanmartinez/purescript-interpolate.git",
+    "version": "v2.0.1"
+  },
   "invariant": {
     "dependencies": [
       "prelude"

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -1,0 +1,6 @@
+{ interpolate =
+    { dependencies = [ "prelude" ]
+    , repo = "https://github.com/jordanmartinez/purescript-interpolate.git"
+    , version = "v2.0.1"
+    }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -78,5 +78,6 @@ let packages =
       ⫽ ./groups/ebmtranceboy.dhall
       ⫽ ./groups/purescript-concur.dhall
       ⫽ ./groups/csicar.dhall
+      ⫽ ./groups/jordanmartinez.dhall
 
 in  packages


### PR DESCRIPTION
Before merging this, please be aware of these two things.

First, ["Registering bower package names is not supported anymore"](https://github.com/JordanMartinez/purescript-interpolate/issues/1#issue-548595305) (related issue: purescript/pursuit#402)

Second, this does not work...
```bash
$> bower i purescript-interpolate
bower ENOTFOUND     Package purescript-interpolate not found
```
... but this does

```bash
$> bower i jordanmartinez/purescript-interpolate
```

If there are other libraries that build upon this one, I'm not sure whether the above facts will be an issue or not as `bower i -p` seems to work.