### PR TITLE
Updates 2020-01-18

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1130,7 +1130,7 @@
       "freedom"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-virtualized.git",
-    "version": "v1.0.0"
+    "version": "v1.1.0"
   },
   "freedom-window-resize": {
     "dependencies": [
@@ -1310,7 +1310,7 @@
       "record"
     ],
     "repo": "https://github.com/citizennet/purescript-halogen-select.git",
-    "version": "v5.0.0-rc.3"
+    "version": "v5.0.0-rc.4"
   },
   "halogen-vdom": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1729,7 +1729,7 @@
   "metadata": {
     "dependencies": [],
     "repo": "https://github.com/spacchetti/purescript-metadata.git",
-    "version": "v0.13.5"
+    "version": "v0.13.6"
   },
   "milkis": {
     "dependencies": [

--- a/src/groups/citizennet.dhall
+++ b/src/groups/citizennet.dhall
@@ -17,6 +17,6 @@
 , halogen-select =
     { dependencies = [ "halogen", "record" ]
     , repo = "https://github.com/citizennet/purescript-halogen-select.git"
-    , version = "v5.0.0-rc.3"
+    , version = "v5.0.0-rc.4"
     }
 }

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -38,7 +38,7 @@
     { dependencies = [ "freedom" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-virtualized.git"
-    , version = "v1.0.0"
+    , version = "v1.1.0"
     }
 , freedom-window-resize =
     { dependencies = [ "freedom" ]

--- a/src/groups/spacchetti.dhall
+++ b/src/groups/spacchetti.dhall
@@ -1,6 +1,6 @@
 { metadata =
     { dependencies = [] : List Text
     , repo = "https://github.com/spacchetti/purescript-metadata.git"
-    , version = "v0.13.5"
+    , version = "v0.13.6"
     }
 }


### PR DESCRIPTION
Updated packages:
- [`freedom-virtualized` upgraded to `v1.1.0`](https://github.com/purescript-freedom/purescript-freedom-virtualized/releases/tag/v1.1.0)
- [`halogen-select` upgraded to `v5.0.0-rc.4`](https://github.com/citizennet/purescript-halogen-select/releases/tag/v5.0.0-rc.4)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
