### PR TITLE
Updates 2020-01-19

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3463,7 +3463,7 @@
       "type-equality"
     ],
     "repo": "https://github.com/purescript/purescript-typelevel-prelude.git",
-    "version": "v5.0.1"
+    "version": "v5.0.2"
   },
   "uint": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -541,7 +541,7 @@
 , typelevel-prelude =
     { dependencies = [ "prelude", "proxy", "type-equality" ]
     , repo = "https://github.com/purescript/purescript-typelevel-prelude.git"
-    , version = "v5.0.1"
+    , version = "v5.0.2"
     }
 , unfoldable =
     { dependencies =


### PR DESCRIPTION
Updated packages:
- [`typelevel-prelude` upgraded to `v5.0.2`](https://github.com/purescript/purescript-typelevel-prelude/releases/tag/v5.0.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
