### PR TITLE
Updates 2020-01-22

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1130,7 +1130,7 @@
       "freedom"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-virtualized.git",
-    "version": "v1.1.0"
+    "version": "v2.0.0"
   },
   "freedom-window-resize": {
     "dependencies": [

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -38,7 +38,7 @@
     { dependencies = [ "freedom" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-virtualized.git"
-    , version = "v1.1.0"
+    , version = "v2.0.0"
     }
 , freedom-window-resize =
     { dependencies = [ "freedom" ]


### PR DESCRIPTION
Updated packages:
- [`freedom-virtualized` upgraded to `v2.0.0`](https://github.com/purescript-freedom/purescript-freedom-virtualized/releases/tag/v2.0.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
