### PR TITLE
Updates 2020-01-30

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2541,7 +2541,7 @@
       "quickcheck"
     ],
     "repo": "https://github.com/garyb/purescript-quickcheck-laws.git",
-    "version": "v5.0.1"
+    "version": "v5.1.0"
   },
   "quotient": {
     "dependencies": [
@@ -3601,7 +3601,7 @@
       "maybe"
     ],
     "repo": "https://github.com/spicydonuts/purescript-uuid.git",
-    "version": "v6.0.0"
+    "version": "v6.0.1"
   },
   "validation": {
     "dependencies": [

--- a/src/groups/csicar.dhall
+++ b/src/groups/csicar.dhall
@@ -1,22 +1,22 @@
 { sized-matrices =
-  { dependencies =
-    [ "sized-vectors"
-    , "prelude"
-    , "foldable-traversable"
-    , "maybe"
-    , "arrays"
-    , "unfoldable"
-    , "typelevel"
-    , "distributive"
-    , "vectorfield"
-    , "strings"
-    ]
-  , repo = "https://github.com/csicar/purescript-sized-matrices"
-  , version = "v0.2.1"
-  }
+    { dependencies =
+      [ "sized-vectors"
+      , "prelude"
+      , "foldable-traversable"
+      , "maybe"
+      , "arrays"
+      , "unfoldable"
+      , "typelevel"
+      , "distributive"
+      , "vectorfield"
+      , "strings"
+      ]
+    , repo = "https://github.com/csicar/purescript-sized-matrices"
+    , version = "v0.2.1"
+    }
 , vectorfield =
-  { dependencies = [ "console", "effect", "group", "prelude", "psci-support" ]
-  , repo = "https://github.com/csicar/purescript-vectorfield.git"
-  , version = "v1.0.1"
-  }
+    { dependencies = [ "console", "effect", "group", "prelude", "psci-support" ]
+    , repo = "https://github.com/csicar/purescript-vectorfield.git"
+    , version = "v1.0.1"
+    }
 }

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -11,6 +11,6 @@
 , quickcheck-laws =
     { dependencies = [ "enums", "proxy", "quickcheck" ]
     , repo = "https://github.com/garyb/purescript-quickcheck-laws.git"
-    , version = "v5.0.1"
+    , version = "v5.1.0"
     }
 }

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -14,6 +14,6 @@
 , uuid =
     { dependencies = [ "effect", "maybe" ]
     , repo = "https://github.com/spicydonuts/purescript-uuid.git"
-    , version = "v6.0.0"
+    , version = "v6.0.1"
     }
 }


### PR DESCRIPTION
Updated packages:
- [`quickcheck-laws` upgraded to `v5.1.0`](https://github.com/garyb/purescript-quickcheck-laws/releases/tag/v5.1.0)
- [`uuid` upgraded to `v6.0.1`](https://github.com/spicydonuts/purescript-uuid/releases/tag/v6.0.1)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
