### PR TITLE
Updates 2020-01-31

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3019,11 +3019,13 @@
   },
   "sized-vectors": {
     "dependencies": [
+      "argonaut",
       "arrays",
       "distributive",
       "foldable-traversable",
       "maybe",
       "prelude",
+      "quickcheck",
       "typelevel",
       "unfoldable"
     ],

--- a/packages.json
+++ b/packages.json
@@ -3028,7 +3028,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/bodil/purescript-sized-vectors.git",
-    "version": "v4.0.0"
+    "version": "v5.0.0"
   },
   "slug": {
     "dependencies": [

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -13,6 +13,8 @@
       , "prelude"
       , "typelevel"
       , "unfoldable"
+      , "quickcheck"
+      , "argonaut"
       ]
     , repo = "https://github.com/bodil/purescript-sized-vectors.git"
     , version = "v5.0.0"

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -15,7 +15,7 @@
       , "unfoldable"
       ]
     , repo = "https://github.com/bodil/purescript-sized-vectors.git"
-    , version = "v4.0.0"
+    , version = "v5.0.0"
     }
 , smolder =
     { dependencies =


### PR DESCRIPTION
Updated packages:
- [`sized-vectors` upgraded to `v5.0.0`](https://github.com/bodil/purescript-sized-vectors/releases/tag/v5.0.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
