### PR TITLE
Updates 2020-02-17

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -736,7 +736,7 @@
       "sunde"
     ],
     "repo": "https://github.com/nsaunders/purescript-dotenv.git",
-    "version": "v1.0.0"
+    "version": "v1.1.0"
   },
   "drawing": {
     "dependencies": [
@@ -1336,7 +1336,7 @@
       "web-html"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen-vdom.git",
-    "version": "v6.1.0"
+    "version": "v6.1.2"
   },
   "heterogeneous": {
     "dependencies": [
@@ -1373,7 +1373,7 @@
       "string-parsers"
     ],
     "repo": "https://github.com/rnons/purescript-html-parser-halogen.git",
-    "version": "v1.0.0-rc.1"
+    "version": "v1.0.0-rc.2"
   },
   "http-methods": {
     "dependencies": [
@@ -2391,7 +2391,7 @@
       "tuples"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-profunctor-lenses.git",
-    "version": "v6.2.0"
+    "version": "v6.3.0"
   },
   "promises": {
     "dependencies": [
@@ -2792,7 +2792,7 @@
       "web-html"
     ],
     "repo": "https://github.com/slamdata/purescript-routing.git",
-    "version": "v9.0.0"
+    "version": "v9.0.1"
   },
   "routing-duplex": {
     "dependencies": [
@@ -3028,7 +3028,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/bodil/purescript-sized-vectors.git",
-    "version": "v4.0.0"
+    "version": "v5.0.0"
   },
   "slug": {
     "dependencies": [
@@ -3567,7 +3567,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/fehrenbach/purescript-unordered-collections.git",
-    "version": "v1.8.2"
+    "version": "v1.8.3"
   },
   "unsafe-coerce": {
     "dependencies": [],

--- a/packages.json
+++ b/packages.json
@@ -3001,29 +3001,15 @@
     "repo": "https://github.com/reactormonk/purescript-simple-timestamp.git",
     "version": "v3.0.0"
   },
-  "sized-matrices": {
-    "dependencies": [
-      "arrays",
-      "distributive",
-      "foldable-traversable",
-      "maybe",
-      "prelude",
-      "sized-vectors",
-      "strings",
-      "typelevel",
-      "unfoldable",
-      "vectorfield"
-    ],
-    "repo": "https://github.com/csicar/purescript-sized-matrices",
-    "version": "v0.2.1"
-  },
   "sized-vectors": {
     "dependencies": [
+      "argonaut",
       "arrays",
       "distributive",
       "foldable-traversable",
       "maybe",
       "prelude",
+      "quickcheck",
       "typelevel",
       "unfoldable"
     ],

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -15,7 +15,7 @@
       , "unfoldable"
       ]
     , repo = "https://github.com/bodil/purescript-sized-vectors.git"
-    , version = "v4.0.0"
+    , version = "v5.0.0"
     }
 , smolder =
     { dependencies =

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -6,11 +6,13 @@
     }
 , sized-vectors =
     { dependencies =
-      [ "arrays"
+      [ "argonaut"
+      , "arrays"
       , "distributive"
       , "foldable-traversable"
       , "maybe"
       , "prelude"
+      , "quickcheck"
       , "typelevel"
       , "unfoldable"
       ]

--- a/src/groups/csicar.dhall
+++ b/src/groups/csicar.dhall
@@ -1,4 +1,4 @@
-{ sized-matrices =
+{- sized-matrices =
     { dependencies =
       [ "sized-vectors"
       , "prelude"
@@ -14,7 +14,8 @@
     , repo = "https://github.com/csicar/purescript-sized-matrices"
     , version = "v0.2.1"
     }
-, vectorfield =
+, -}
+{ vectorfield =
     { dependencies = [ "console", "effect", "group", "prelude", "psci-support" ]
     , repo = "https://github.com/csicar/purescript-vectorfield.git"
     , version = "v1.0.1"

--- a/src/groups/fehrenbach.dhall
+++ b/src/groups/fehrenbach.dhall
@@ -11,6 +11,6 @@
       ]
     , repo =
         "https://github.com/fehrenbach/purescript-unordered-collections.git"
-    , version = "v1.8.2"
+    , version = "v1.8.3"
     }
 }

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -11,7 +11,7 @@
       , "sunde"
       ]
     , repo = "https://github.com/nsaunders/purescript-dotenv.git"
-    , version = "v1.0.0"
+    , version = "v1.1.0"
     }
 , nodetrout =
     { dependencies =

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -185,7 +185,7 @@
       ]
     , repo =
         "https://github.com/purescript-contrib/purescript-profunctor-lenses.git"
-    , version = "v6.2.0"
+    , version = "v6.3.0"
     }
 , react =
     { dependencies =

--- a/src/groups/rnons.dhall
+++ b/src/groups/rnons.dhall
@@ -6,7 +6,7 @@
 , html-parser-halogen =
     { dependencies = [ "generics-rep", "halogen", "prelude", "string-parsers" ]
     , repo = "https://github.com/rnons/purescript-html-parser-halogen.git"
-    , version = "v1.0.0-rc.1"
+    , version = "v1.0.0-rc.2"
     }
 , svg-parser =
     { dependencies = [ "generics-rep", "prelude", "string-parsers" ]

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -134,7 +134,7 @@
       , "web-html"
       ]
     , repo = "https://github.com/slamdata/purescript-halogen-vdom.git"
-    , version = "v6.1.0"
+    , version = "v6.1.2"
     }
 , pathy =
     { dependencies =
@@ -171,7 +171,7 @@
       , "web-html"
       ]
     , repo = "https://github.com/slamdata/purescript-routing.git"
-    , version = "v9.0.0"
+    , version = "v9.0.1"
     }
 , uri =
     { dependencies =


### PR DESCRIPTION
Updated packages:
- [`dotenv` upgraded to `v1.1.0`](https://github.com/nsaunders/purescript-dotenv/releases/tag/v1.1.0)
- [`halogen-vdom` upgraded to `v6.1.2`](https://github.com/slamdata/purescript-halogen-vdom/releases/tag/v6.1.2)
- [`html-parser-halogen` upgraded to `v1.0.0-rc.2`](https://github.com/rnons/purescript-html-parser-halogen/releases/tag/v1.0.0-rc.2)
- [`profunctor-lenses` upgraded to `v6.3.0`](https://github.com/purescript-contrib/purescript-profunctor-lenses/releases/tag/v6.3.0)
- [`routing` upgraded to `v9.0.1`](https://github.com/slamdata/purescript-routing/releases/tag/v9.0.1)
- [`sized-vectors` upgraded to `v5.0.0`](https://github.com/bodil/purescript-sized-vectors/releases/tag/v5.0.0)
- [`unordered-collections` upgraded to `v1.8.3`](https://github.com/fehrenbach/purescript-unordered-collections/releases/tag/v1.8.3)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
