### PR TITLE
Updates 2020-02-28

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2647,7 +2647,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v4.2.1"
+    "version": "v4.2.2"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -9,7 +9,7 @@
       , "unsafe-reference"
       ]
     , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-    , version = "v4.2.1"
+    , version = "v4.2.2"
     }
 , uuid =
     { dependencies = [ "effect", "maybe" ]


### PR DESCRIPTION
Updated packages:
- [`react-basic-hooks` upgraded to `v4.2.2`](https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v4.2.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
