### PR TITLE
Updates 2020-03-03

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -70,7 +70,7 @@
       "web-xhr"
     ],
     "repo": "https://github.com/slamdata/purescript-affjax.git",
-    "version": "v10.0.0"
+    "version": "v9.0.1"
   },
   "ansi": {
     "dependencies": [
@@ -170,7 +170,7 @@
       "uint"
     ],
     "repo": "https://github.com/jacereda/purescript-arraybuffer.git",
-    "version": "v10.0.2"
+    "version": "v9.0.0"
   },
   "arraybuffer-types": {
     "dependencies": [],
@@ -988,7 +988,7 @@
       "record"
     ],
     "repo": "https://github.com/paf31/purescript-foreign-generic.git",
-    "version": "v10.0.0"
+    "version": "v9.0.0"
   },
   "foreign-object": {
     "dependencies": [
@@ -1429,7 +1429,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/cprussin/purescript-httpure.git",
-    "version": "v0.10.0"
+    "version": "v0.9.0"
   },
   "httpure-contrib-biscotti": {
     "dependencies": [
@@ -1477,7 +1477,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/purescript-hyper/hyper.git",
-    "version": "v0.11.0"
+    "version": "v0.9.1"
   },
   "hypertrout": {
     "dependencies": [
@@ -1488,7 +1488,7 @@
       "trout"
     ],
     "repo": "https://github.com/purescript-hyper/purescript-hypertrout.git",
-    "version": "v0.11.0"
+    "version": "v0.9.0"
   },
   "identity": {
     "dependencies": [
@@ -2468,7 +2468,7 @@
       "random"
     ],
     "repo": "https://github.com/kRITZCREEK/purescript-psc-ide.git",
-    "version": "v15.0.1"
+    "version": "v9.0.1"
   },
   "psci-support": {
     "dependencies": [
@@ -2488,7 +2488,7 @@
       "pairs"
     ],
     "repo": "https://github.com/sharkdp/purescript-quantities.git",
-    "version": "v10.0.0"
+    "version": "v9.0.0"
   },
   "querydsl": {
     "dependencies": [
@@ -2509,7 +2509,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/Dretch/purescript-querydsl.git",
-    "version": "v0.10.1"
+    "version": "v0.9.6"
   },
   "quickcheck": {
     "dependencies": [
@@ -2634,7 +2634,7 @@
       "web-html"
     ],
     "repo": "https://github.com/lumihq/purescript-react-basic.git",
-    "version": "v13.0.0"
+    "version": "v9.0.1"
   },
   "react-basic-hooks": {
     "dependencies": [
@@ -2929,7 +2929,7 @@
       "prelude"
     ],
     "repo": "https://github.com/bodil/purescript-signal.git",
-    "version": "v10.1.0"
+    "version": "v9.0.0"
   },
   "sijidou": {
     "dependencies": [
@@ -3067,7 +3067,7 @@
       "tuples"
     ],
     "repo": "https://github.com/bodil/purescript-smolder.git",
-    "version": "v12.3.0"
+    "version": "v9.0.0"
   },
   "snabbdom": {
     "dependencies": [
@@ -3227,7 +3227,7 @@
       "strings"
     ],
     "repo": "https://github.com/menelaos/purescript-stringutils.git",
-    "version": "v0.0.10"
+    "version": "v0.0.9"
   },
   "strongcheck": {
     "dependencies": [
@@ -3370,7 +3370,7 @@
       "strings"
     ],
     "repo": "https://github.com/bodil/purescript-test-unit.git",
-    "version": "v15.0.0"
+    "version": "v9.1.0"
   },
   "these": {
     "dependencies": [
@@ -3453,7 +3453,7 @@
       "uri"
     ],
     "repo": "https://github.com/purescript-hyper/purescript-trout.git",
-    "version": "v0.12.2"
+    "version": "v0.9.1"
   },
   "trout-client": {
     "dependencies": [
@@ -3463,7 +3463,7 @@
       "trout"
     ],
     "repo": "https://github.com/purescript-hyper/purescript-trout-client.git",
-    "version": "v0.12.0"
+    "version": "v0.8.0"
   },
   "tuples": {
     "dependencies": [

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -2,7 +2,7 @@
     { dependencies =
       [ "aff", "foldable-traversable", "js-timers", "maybe", "prelude" ]
     , repo = "https://github.com/bodil/purescript-signal.git"
-    , version = "v10.1.0"
+    , version = "v9.0.0"
     }
 , sized-vectors =
     { dependencies =
@@ -31,7 +31,7 @@
       , "tuples"
       ]
     , repo = "https://github.com/bodil/purescript-smolder.git"
-    , version = "v12.3.0"
+    , version = "v9.0.0"
     }
 , test-unit =
     { dependencies =
@@ -47,7 +47,7 @@
       , "strings"
       ]
     , repo = "https://github.com/bodil/purescript-test-unit.git"
-    , version = "v15.0.0"
+    , version = "v9.1.0"
     }
 , typelevel =
     { dependencies =

--- a/src/groups/cprussin.dhall
+++ b/src/groups/cprussin.dhall
@@ -32,7 +32,7 @@
       , "unsafe-coerce"
       ]
     , repo = "https://github.com/cprussin/purescript-httpure.git"
-    , version = "v0.10.0"
+    , version = "v0.9.0"
     }
 , monad-logger =
     { dependencies =

--- a/src/groups/dretch.dhall
+++ b/src/groups/dretch.dhall
@@ -17,6 +17,6 @@
       , "nullable"
       ]
     , repo = "https://github.com/Dretch/purescript-querydsl.git"
-    , version = "v0.10.1"
+    , version = "v0.9.6"
     }
 }

--- a/src/groups/jacereda.dhall
+++ b/src/groups/jacereda.dhall
@@ -12,6 +12,6 @@
       , "uint"
       ]
     , repo = "https://github.com/jacereda/purescript-arraybuffer.git"
-    , version = "v10.0.2"
+    , version = "v9.0.0"
     }
 }

--- a/src/groups/kritzcreek.dhall
+++ b/src/groups/kritzcreek.dhall
@@ -16,6 +16,6 @@
       , "random"
       ]
     , repo = "https://github.com/kRITZCREEK/purescript-psc-ide.git"
-    , version = "v15.0.1"
+    , version = "v9.0.1"
     }
 }

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -14,6 +14,6 @@
       , "web-html"
       ]
     , repo = "https://github.com/lumihq/purescript-react-basic.git"
-    , version = "v13.0.0"
+    , version = "v9.0.1"
     }
 }

--- a/src/groups/menelaos.dhall
+++ b/src/groups/menelaos.dhall
@@ -45,6 +45,6 @@
       , "strings"
       ]
     , repo = "https://github.com/menelaos/purescript-stringutils.git"
-    , version = "v0.0.10"
+    , version = "v0.0.9"
     }
 }

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -51,7 +51,7 @@
       , "record"
       ]
     , repo = "https://github.com/paf31/purescript-foreign-generic.git"
-    , version = "v10.0.0"
+    , version = "v9.0.0"
     }
 , leibniz =
     { dependencies = [ "prelude", "unsafe-coerce" ]

--- a/src/groups/purescript-hyper.dhall
+++ b/src/groups/purescript-hyper.dhall
@@ -24,22 +24,22 @@
       , "typelevel-prelude"
       ]
     , repo = "https://github.com/purescript-hyper/hyper.git"
-    , version = "v0.11.0"
+    , version = "v0.9.1"
     }
 , hypertrout =
     { dependencies =
       [ "argonaut-generic", "console", "hyper", "prelude", "trout" ]
     , repo = "https://github.com/purescript-hyper/purescript-hypertrout.git"
-    , version = "v0.11.0"
+    , version = "v0.9.0"
     }
 , trout =
     { dependencies = [ "argonaut", "media-types", "prelude", "smolder", "uri" ]
     , repo = "https://github.com/purescript-hyper/purescript-trout.git"
-    , version = "v0.12.2"
+    , version = "v0.9.1"
     }
 , trout-client =
     { dependencies = [ "affjax", "argonaut-generic", "prelude", "trout" ]
     , repo = "https://github.com/purescript-hyper/purescript-trout-client.git"
-    , version = "v0.12.0"
+    , version = "v0.8.0"
     }
 }

--- a/src/groups/sharkdp.dhall
+++ b/src/groups/sharkdp.dhall
@@ -57,6 +57,6 @@
     { dependencies =
       [ "lists", "foldable-traversable", "numbers", "pairs", "decimals" ]
     , repo = "https://github.com/sharkdp/purescript-quantities.git"
-    , version = "v10.0.0"
+    , version = "v9.0.0"
     }
 }

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -39,7 +39,7 @@
       , "web-xhr"
       ]
     , repo = "https://github.com/slamdata/purescript-affjax.git"
-    , version = "v10.0.0"
+    , version = "v9.0.1"
     }
 , css =
     { dependencies =


### PR DESCRIPTION
Updated packages:
- [`affjax` upgraded to `v9.0.1`](https://github.com/slamdata/purescript-affjax/releases/tag/v9.0.1)
- [`arraybuffer` upgraded to `v9.0.0`](https://github.com/jacereda/purescript-arraybuffer/releases/tag/v9.0.0)
- [`foreign-generic` upgraded to `v9.0.0`](https://github.com/paf31/purescript-foreign-generic/releases/tag/v9.0.0)
- [`httpure` upgraded to `v0.9.0`](https://github.com/cprussin/purescript-httpure/releases/tag/v0.9.0)
- [`hyper` upgraded to `v0.9.1`](https://github.com/purescript-hyper/purescript-hyper/releases/tag/v0.9.1)
- [`hypertrout` upgraded to `v0.9.0`](https://github.com/purescript-hyper/purescript-hypertrout/releases/tag/v0.9.0)
- [`psc-ide` upgraded to `v9.0.1`](https://github.com/kRITZCREEK/purescript-psc-ide/releases/tag/v9.0.1)
- [`quantities` upgraded to `v9.0.0`](https://github.com/sharkdp/purescript-quantities/releases/tag/v9.0.0)
- [`querydsl` upgraded to `v0.9.6`](https://github.com/Dretch/purescript-querydsl/releases/tag/v0.9.6)
- [`react-basic` upgraded to `v9.0.1`](https://github.com/lumihq/purescript-react-basic/releases/tag/v9.0.1)
- [`signal` upgraded to `v9.0.0`](https://github.com/bodil/purescript-signal/releases/tag/v9.0.0)
- [`smolder` upgraded to `v9.0.0`](https://github.com/bodil/purescript-smolder/releases/tag/v9.0.0)
- [`stringutils` upgraded to `v0.0.9`](https://github.com/menelaos/purescript-stringutils/releases/tag/v0.0.9)
- [`test-unit` upgraded to `v9.1.0`](https://github.com/bodil/purescript-test-unit/releases/tag/v9.1.0)
- [`trout` upgraded to `v0.9.1`](https://github.com/purescript-hyper/purescript-trout/releases/tag/v0.9.1)
- [`trout-client` upgraded to `v0.8.0`](https://github.com/purescript-hyper/purescript-trout-client/releases/tag/v0.8.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
