### PR TITLE
Add Mergify configuration to auto-merge PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,15 @@
+pull_request_rules:
+- actions:
+    merge:
+      strict: smart
+      method: squash
+  name: Automatically merge pull requests
+  conditions:
+  - status-success=continuous-integration/travis-ci/pr
+  - label=mergify
+  - ! '#changes-requested-reviews-by=0'
+- actions:
+    delete_head_branch: {}
+  name: Delete head branch after merge
+  conditions:
+  - merged


### PR DESCRIPTION
This change has been made by @f-f from https://mergify.io simulator.

Fix #3 

---


<details>
<summary>Mergify commands and options</summary>
<br />
More conditions and actions can be found in the [documention](https://doc.mergify.io/).
<br />
<br />
You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR
- `@Mergifyio backports <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
