### PR TITLE
Updates 2020-03-31

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1111,14 +1111,14 @@
       "js-timers"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-now.git",
-    "version": "v2.0.0"
+    "version": "v3.0.0"
   },
   "freedom-portal": {
     "dependencies": [
       "freedom"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-portal.git",
-    "version": "v1.0.0"
+    "version": "v2.0.0"
   },
   "freedom-router": {
     "dependencies": [
@@ -1126,7 +1126,7 @@
       "profunctor"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-router.git",
-    "version": "v1.0.1"
+    "version": "v2.0.0"
   },
   "freedom-transition": {
     "dependencies": [
@@ -1134,14 +1134,14 @@
       "js-timers"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-transition.git",
-    "version": "v1.0.1"
+    "version": "v2.0.0"
   },
   "freedom-virtualized": {
     "dependencies": [
       "freedom"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-virtualized.git",
-    "version": "v2.0.0"
+    "version": "v3.0.0"
   },
   "freedom-window-resize": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1280,7 +1280,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen.git",
-    "version": "v5.0.0-rc.7"
+    "version": "v5.0.0-rc.8"
   },
   "halogen-bootstrap": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1103,7 +1103,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom.git",
-    "version": "v1.4.1"
+    "version": "v2.0.0"
   },
   "freedom-now": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1148,7 +1148,7 @@
       "freedom"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-window-resize.git",
-    "version": "v1.0.0"
+    "version": "v2.0.0"
   },
   "freet": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -3719,7 +3719,7 @@
       "maybe"
     ],
     "repo": "https://github.com/spicydonuts/purescript-uuid.git",
-    "version": "v6.0.1"
+    "version": "v6.1.0"
   },
   "validation": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -3715,8 +3715,11 @@
   },
   "uuid": {
     "dependencies": [
+      "console",
       "effect",
-      "maybe"
+      "foreign-generic",
+      "maybe",
+      "spec"
     ],
     "repo": "https://github.com/spicydonuts/purescript-uuid.git",
     "version": "v6.1.0"

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -44,6 +44,6 @@
     { dependencies = [ "freedom" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-window-resize.git"
-    , version = "v1.0.0"
+    , version = "v2.0.0"
     }
 }

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -14,31 +14,31 @@
 , freedom-now =
     { dependencies = [ "freedom", "js-timers" ]
     , repo = "https://github.com/purescript-freedom/purescript-freedom-now.git"
-    , version = "v2.0.0"
+    , version = "v3.0.0"
     }
 , freedom-portal =
     { dependencies = [ "freedom" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-portal.git"
-    , version = "v1.0.0"
+    , version = "v2.0.0"
     }
 , freedom-router =
     { dependencies = [ "freedom", "profunctor" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-router.git"
-    , version = "v1.0.1"
+    , version = "v2.0.0"
     }
 , freedom-transition =
     { dependencies = [ "freedom", "js-timers" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-transition.git"
-    , version = "v1.0.1"
+    , version = "v2.0.0"
     }
 , freedom-virtualized =
     { dependencies = [ "freedom" ]
     , repo =
         "https://github.com/purescript-freedom/purescript-freedom-virtualized.git"
-    , version = "v2.0.0"
+    , version = "v3.0.0"
     }
 , freedom-window-resize =
     { dependencies = [ "freedom" ]

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -9,7 +9,7 @@
       , "web-html"
       ]
     , repo = "https://github.com/purescript-freedom/purescript-freedom.git"
-    , version = "v1.4.1"
+    , version = "v2.0.0"
     }
 , freedom-now =
     { dependencies = [ "freedom", "js-timers" ]

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -108,7 +108,7 @@
       , "web-uievents"
       ]
     , repo = "https://github.com/slamdata/purescript-halogen.git"
-    , version = "v5.0.0-rc.7"
+    , version = "v5.0.0-rc.8"
     }
 , halogen-bootstrap =
     { dependencies = [ "halogen" ]

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -14,6 +14,6 @@
 , uuid =
     { dependencies = [ "effect", "maybe" ]
     , repo = "https://github.com/spicydonuts/purescript-uuid.git"
-    , version = "v6.0.1"
+    , version = "v6.1.0"
     }
 }

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -12,7 +12,7 @@
     , version = "v4.2.2"
     }
 , uuid =
-    { dependencies = [ "effect", "maybe" ]
+    { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]
     , repo = "https://github.com/spicydonuts/purescript-uuid.git"
     , version = "v6.1.0"
     }


### PR DESCRIPTION
Updated packages:
- [`halogen` upgraded to `v5.0.0-rc.8`](https://github.com/slamdata/purescript-halogen/releases/tag/v5.0.0-rc.8)
- [`uuid` upgraded to `v6.1.0`](https://github.com/spicydonuts/purescript-uuid/releases/tag/v6.1.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
