### PR TITLE
Updates 2020-04-15

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1278,7 +1278,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen.git",
-    "version": "v5.0.0-rc.8"
+    "version": "v5.0.0-rc.9"
   },
   "halogen-bootstrap": {
     "dependencies": [

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -108,7 +108,7 @@
     , "web-uievents"
     ]
   , repo = "https://github.com/slamdata/purescript-halogen.git"
-  , version = "v5.0.0-rc.8"
+  , version = "v5.0.0-rc.9"
   }
 , halogen-bootstrap =
   { dependencies = [ "halogen" ]


### PR DESCRIPTION
Updated packages:
- [`halogen` upgraded to `v5.0.0-rc.9`](https://github.com/slamdata/purescript-halogen/releases/tag/v5.0.0-rc.9)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
