### PR TITLE
arraybuffer-class, zeta, and an update to uint

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1865,6 +1865,22 @@
     "repo": "https://github.com/Thimoteus/purescript-mmorph.git",
     "version": "v5.1.0"
   },
+  "monad-control": {
+    "dependencies": [
+      "aff",
+      "effect",
+      "either",
+      "freet",
+      "functors",
+      "identity",
+      "lists",
+      "prelude",
+      "transformers",
+      "tuples"
+    ],
+    "repo": "https://github.com/athanclark/purescript-monad-control.git",
+    "version": "v5.0.0"
+  },
   "monad-logger": {
     "dependencies": [
       "aff",

--- a/packages.json
+++ b/packages.json
@@ -3947,5 +3947,28 @@
     ],
     "repo": "https://github.com/paf31/purescript-yargs.git",
     "version": "v4.0.0"
+  },
+  "zeta": {
+    "dependencies": [
+      "aff",
+      "arrays",
+      "datetime",
+      "exceptions",
+      "exists",
+      "foldable-traversable",
+      "js-timers",
+      "lcg",
+      "node-buffer",
+      "node-fs",
+      "node-readline",
+      "now",
+      "prelude",
+      "profunctor",
+      "quickcheck",
+      "strings",
+      "transformers"
+    ],
+    "repo": "https://github.com/athanclark/purescript-zeta.git",
+    "version": "v5.0.3"
   }
 }

--- a/packages.json
+++ b/packages.json
@@ -3716,7 +3716,7 @@
       "quickcheck"
     ],
     "repo": "https://github.com/zaquest/purescript-uint.git",
-    "version": "v5.1.3"
+    "version": "v5.1.4"
   },
   "undefinable": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -172,6 +172,24 @@
     "repo": "https://github.com/jacereda/purescript-arraybuffer.git",
     "version": "v10.0.2"
   },
+  "arraybuffer-class": {
+    "dependencies": [
+      "arraybuffer",
+      "console",
+      "effect",
+      "exceptions",
+      "foreign-object",
+      "ordered-collections",
+      "prelude",
+      "psci-support",
+      "quickcheck",
+      "sized-vectors",
+      "strings",
+      "unordered-collections"
+    ],
+    "repo": "https://github.com/athanclark/purescript-arraybuffer-class.git",
+    "version": "v0.2.5"
+  },
   "arraybuffer-types": {
     "dependencies": [],
     "repo": "https://github.com/purescript-contrib/purescript-arraybuffer-types.git",

--- a/packages.json
+++ b/packages.json
@@ -3964,6 +3964,17 @@
     "repo": "https://github.com/paf31/purescript-yargs.git",
     "version": "v4.0.0"
   },
+  "z85": {
+    "dependencies": [
+      "arraybuffer",
+      "numbers",
+      "prelude",
+      "sized-vectors",
+      "stringutils"
+    ],
+    "repo": "https://github.com/athanclark/purescript-z85.git",
+    "version": "v0.0.2"
+  },
   "zeta": {
     "dependencies": [
       "aff",


### PR DESCRIPTION
The dependencies iterated in these packages might be excessive - is there a way to declare "dev-dependencies" in spago / psc-package? If so, I'll likely publish a revision to these later.