### PR TITLE
Updates 2020-04-22

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3720,7 +3720,7 @@
       "quickcheck"
     ],
     "repo": "https://github.com/zaquest/purescript-uint.git",
-    "version": "v5.1.3"
+    "version": "v5.1.4"
   },
   "undefinable": {
     "dependencies": [

--- a/src/groups/zaquest.dhall
+++ b/src/groups/zaquest.dhall
@@ -1,6 +1,6 @@
 { uint =
   { dependencies = [ "generics-rep", "math", "maybe", "quickcheck" ]
   , repo = "https://github.com/zaquest/purescript-uint.git"
-  , version = "v5.1.3"
+  , version = "v5.1.4"
   }
 }


### PR DESCRIPTION
Updated packages:
- [`uint` upgraded to `v5.1.4`](https://github.com/zaquest/purescript-uint/releases/tag/v5.1.4)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
