### PR TITLE
Fix contravariant

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -395,7 +395,7 @@
       "prelude",
       "transformers"
     ],
-    "repo": "git@github.com:doolse/purescript-formatters.git",
+    "repo": "https://github.com/doolse/purescript-formatters.git",
     "version": "compiler/0.12"
   },
   "free": {
@@ -918,8 +918,8 @@
       "transformers",
       "unicode"
     ],
-    "repo": "git@github.com:joncfoo/purescript-parsing.git",
-    "version": "update-for-0.12.0"
+    "repo": "https://github.com/purescript-contrib/purescript-parsing.git",
+    "version": "v5.0.1"
   },
   "partial": {
     "dependencies": [],
@@ -1081,7 +1081,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/doolse/purescript-react-mui.git",
-    "version": "v2.0.0"
+    "version": "v2.0.1"
   },
   "record": {
     "dependencies": [
@@ -1338,8 +1338,8 @@
       "these",
       "unfoldable"
     ],
-    "repo": "https://github.com/doolse/purescript-uri.git",
-    "version": "compiler/0.12"
+    "repo": "https://github.com/slamdata/purescript-uri.git",
+    "version": "v6.0.0"
   },
   "validation": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1100,7 +1100,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/doolse/purescript-react-mui.git",
-    "version": "v3.9.2"
+    "version": "v3.9.3"
   },
   "record": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1081,7 +1081,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/doolse/purescript-react-mui.git",
-    "version": "v2.0.1"
+    "version": "v2.0.2"
   },
   "record": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -204,7 +204,7 @@
       "tuples"
     ],
     "repo": "https://github.com/purescript/purescript-contravariant.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "control": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -125,7 +125,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-arrays.git",
-    "version": "v5.0.0"
+    "version": "v5.1.0"
   },
   "assert": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1100,7 +1100,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/doolse/purescript-react-mui.git",
-    "version": "v2.0.2"
+    "version": "v3.0.0"
   },
   "record": {
     "dependencies": [
@@ -1286,6 +1286,13 @@
     ],
     "repo": "https://github.com/purescript/purescript-transformers.git",
     "version": "v4.1.0"
+  },
+  "tscompat": {
+    "dependencies": [
+      "react"
+    ],
+    "repo": "https://github.com/doolse/purescript-tscompat.git",
+    "version": "v0.0.2"
   },
   "tuples": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -58,6 +58,26 @@
     "repo": "https://github.com/hdgarrood/purescript-ansi",
     "version": "v5.0.0"
   },
+  "argonaut": {
+    "dependencies": [
+      "argonaut-codecs",
+      "argonaut-core",
+      "argonaut-traversals"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-argonaut.git",
+    "version": "v4.0.0"
+  },
+  "argonaut-codecs": {
+    "dependencies": [
+      "argonaut-core",
+      "foreign-object",
+      "integers",
+      "maybe",
+      "ordered-collections"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-argonaut-codecs.git",
+    "version": "v4.0.0"
+  },
   "argonaut-core": {
     "dependencies": [
       "arrays",
@@ -73,6 +93,15 @@
       "tailrec"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-argonaut-core.git",
+    "version": "v4.0.0"
+  },
+  "argonaut-traversals": {
+    "dependencies": [
+      "argonaut-codecs",
+      "argonaut-core",
+      "profunctor-lenses"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-argonaut-traversals.git",
     "version": "v4.0.0"
   },
   "arraybuffer-types": {
@@ -356,6 +385,18 @@
     ],
     "repo": "https://github.com/purescript-contrib/purescript-form-urlencoded.git",
     "version": "v4.0.0"
+  },
+  "formatters": {
+    "dependencies": [
+      "datetime",
+      "generics-rep",
+      "lists",
+      "parsing",
+      "prelude",
+      "transformers"
+    ],
+    "repo": "git@github.com:doolse/purescript-formatters.git",
+    "version": "compiler/0.12"
   },
   "free": {
     "dependencies": [
@@ -864,6 +905,22 @@
     "repo": "https://github.com/purescript/purescript-parallel.git",
     "version": "v4.0.0"
   },
+  "parsing": {
+    "dependencies": [
+      "arrays",
+      "either",
+      "foldable-traversable",
+      "identity",
+      "integers",
+      "lists",
+      "maybe",
+      "strings",
+      "transformers",
+      "unicode"
+    ],
+    "repo": "git@github.com:joncfoo/purescript-parsing.git",
+    "version": "update-for-0.12.0"
+  },
   "partial": {
     "dependencies": [],
     "repo": "https://github.com/purescript/purescript-partial.git",
@@ -995,6 +1052,37 @@
     "repo": "https://github.com/purescript/purescript-random.git",
     "version": "v4.0.0"
   },
+  "react": {
+    "dependencies": [
+      "effect",
+      "exceptions",
+      "maybe",
+      "nullable",
+      "prelude",
+      "typelevel-prelude",
+      "unsafe-coerce"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-react.git",
+    "version": "v6.0.0"
+  },
+  "react-dom": {
+    "dependencies": [
+      "effect",
+      "react",
+      "web-dom"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-react-dom.git",
+    "version": "v6.0.0"
+  },
+  "react-mui": {
+    "dependencies": [
+      "react",
+      "react-dom",
+      "typelevel-prelude"
+    ],
+    "repo": "https://github.com/doolse/purescript-react-mui.git",
+    "version": "v2.0.0"
+  },
   "record": {
     "dependencies": [
       "functions",
@@ -1013,6 +1101,27 @@
     ],
     "repo": "https://github.com/purescript/purescript-refs.git",
     "version": "v4.1.0"
+  },
+  "routing": {
+    "dependencies": [
+      "aff",
+      "console",
+      "control",
+      "effect",
+      "either",
+      "foldable-traversable",
+      "globals",
+      "integers",
+      "lists",
+      "maybe",
+      "prelude",
+      "semirings",
+      "tuples",
+      "validation",
+      "web-html"
+    ],
+    "repo": "https://github.com/slamdata/purescript-routing.git",
+    "version": "v8.0.0"
   },
   "semirings": {
     "dependencies": [
@@ -1217,6 +1326,20 @@
     "dependencies": [],
     "repo": "https://github.com/purescript-contrib/purescript-unsafe-reference",
     "version": "v3.0.0"
+  },
+  "uri": {
+    "dependencies": [
+      "arrays",
+      "generics-rep",
+      "globals",
+      "integers",
+      "parsing",
+      "profunctor-lenses",
+      "these",
+      "unfoldable"
+    ],
+    "repo": "https://github.com/doolse/purescript-uri.git",
+    "version": "compiler/0.12"
   },
   "validation": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -214,6 +214,15 @@
     "repo": "https://github.com/garyb/purescript-debug.git",
     "version": "v4.0.0"
   },
+  "dispatcher-react": {
+    "dependencies": [
+      "aff",
+      "react",
+      "refs"
+    ],
+    "repo": "https://github.com/doolse/purescript-dispatcher-react.git",
+    "version": "v4.0.0"
+  },
   "distributive": {
     "dependencies": [
       "identity",

--- a/packages.json
+++ b/packages.json
@@ -150,8 +150,8 @@
   },
   "base64": {
     "dependencies": [
-      "nullable",
-      "arraybuffer-types"
+      "arraybuffer-types",
+      "nullable"
     ],
     "repo": "https://github.com/athanclark/purescript-base64.git",
     "version": "v1.0.1"
@@ -301,10 +301,10 @@
   "encoding": {
     "dependencies": [
       "arraybuffer-types",
-      "prelude",
-      "functions",
       "either",
-      "exceptions"
+      "exceptions",
+      "functions",
+      "prelude"
     ],
     "repo": "https://github.com/menelaos/purescript-encoding.git",
     "version": "v0.0.5"
@@ -441,8 +441,8 @@
     "dependencies": [
       "const",
       "exists",
-      "lists",
-      "gen"
+      "gen",
+      "lists"
     ],
     "repo": "https://github.com/ethul/purescript-freeap.git",
     "version": "v5.0.0"
@@ -1100,7 +1100,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/doolse/purescript-react-mui.git",
-    "version": "v3.1.0"
+    "version": "v3.9.2"
   },
   "record": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -148,6 +148,14 @@
     "repo": "https://github.com/slamdata/purescript-avar.git",
     "version": "v3.0.0"
   },
+  "base64": {
+    "dependencies": [
+      "nullable",
+      "arraybuffer-types"
+    ],
+    "repo": "https://github.com/athanclark/purescript-base64.git",
+    "version": "v1.0.1"
+  },
   "bifunctors": {
     "dependencies": [
       "newtype",
@@ -289,6 +297,17 @@
     ],
     "repo": "https://github.com/purescript/purescript-either.git",
     "version": "v4.0.0"
+  },
+  "encoding": {
+    "dependencies": [
+      "arraybuffer-types",
+      "prelude",
+      "functions",
+      "either",
+      "exceptions"
+    ],
+    "repo": "https://github.com/menelaos/purescript-encoding.git",
+    "version": "v0.0.5"
   },
   "enums": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1100,7 +1100,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/doolse/purescript-react-mui.git",
-    "version": "v3.0.0"
+    "version": "v3.1.0"
   },
   "record": {
     "dependencies": [
@@ -1292,7 +1292,7 @@
       "react"
     ],
     "repo": "https://github.com/doolse/purescript-tscompat.git",
-    "version": "v0.0.2"
+    "version": "v1.0.1"
   },
   "tuples": {
     "dependencies": [


### PR DESCRIPTION
Contravaraint as a circular dependency which can cause newer versions of purescript to fail