### PR TITLE
Updates 2020-04-28

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2759,7 +2759,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -10,7 +10,7 @@
     , "unsafe-reference"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v5.0.0"
+  , version = "v5.0.1"
   }
 , uuid =
   { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]


### PR DESCRIPTION
Updated packages:
- [`react-basic-hooks` upgraded to `v5.0.1`](https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v5.0.1)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
