### PR TITLE
Updates 2020-04-29

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -573,7 +573,7 @@
       "tailrec"
     ],
     "repo": "https://github.com/purescript-concur/purescript-concur-core.git",
-    "version": "v0.4.1"
+    "version": "v0.4.2"
   },
   "concur-react": {
     "dependencies": [
@@ -592,7 +592,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-concur/purescript-concur-react.git",
-    "version": "v0.4.1"
+    "version": "v0.4.2"
   },
   "console": {
     "dependencies": [
@@ -2759,7 +2759,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v5.0.1"
+    "version": "v5.1.0"
   },
   "react-basic-native": {
     "dependencies": [

--- a/src/groups/purescript-concur.dhall
+++ b/src/groups/purescript-concur.dhall
@@ -11,7 +11,7 @@
     , "tailrec"
     ]
   , repo = "https://github.com/purescript-concur/purescript-concur-core.git"
-  , version = "v0.4.1"
+  , version = "v0.4.2"
   }
 , concur-react =
   { dependencies =
@@ -30,6 +30,6 @@
     , "web-html"
     ]
   , repo = "https://github.com/purescript-concur/purescript-concur-react.git"
-  , version = "v0.4.1"
+  , version = "v0.4.2"
   }
 }

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -10,7 +10,7 @@
     , "unsafe-reference"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v5.0.1"
+  , version = "v5.1.0"
   }
 , uuid =
   { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]


### PR DESCRIPTION
Updated packages:
- [`concur-core` upgraded to `v0.4.2`](https://github.com/purescript-concur/purescript-concur-core/releases/tag/v0.4.2)
- [`concur-react` upgraded to `v0.4.2`](https://github.com/purescript-concur/purescript-concur-react/releases/tag/v0.4.2)
- [`react-basic-hooks` upgraded to `v5.1.0`](https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v5.1.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
