### PR TITLE
Updates 2020-05-01

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1332,7 +1332,7 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.1.0"
+    "version": "v0.2.0"
   },
   "halogen-hooks-extra": {
     "dependencies": [
@@ -2759,7 +2759,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v5.1.0"
+    "version": "v5.2.0"
   },
   "react-basic-native": {
     "dependencies": [
@@ -3116,7 +3116,7 @@
       "record-extra"
     ],
     "repo": "https://github.com/oreshinya/purescript-simple-i18n.git",
-    "version": "v0.1.1"
+    "version": "v0.1.2"
   },
   "simple-json": {
     "dependencies": [
@@ -3423,7 +3423,7 @@
       "tuples"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-strongcheck.git",
-    "version": "v4.1.1"
+    "version": "v5.0.0"
   },
   "struct": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1334,6 +1334,13 @@
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
     "version": "v0.2.0"
   },
+  "halogen-hooks-extra": {
+    "dependencies": [
+      "halogen-hooks"
+    ],
+    "repo": "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git",
+    "version": "v0.3.0"
+  },
   "halogen-select": {
     "dependencies": [
       "halogen",
@@ -3384,6 +3391,39 @@
     ],
     "repo": "https://github.com/menelaos/purescript-stringutils.git",
     "version": "v0.0.10"
+  },
+  "strongcheck": {
+    "dependencies": [
+      "arrays",
+      "console",
+      "control",
+      "datetime",
+      "effect",
+      "either",
+      "enums",
+      "exceptions",
+      "foldable-traversable",
+      "free",
+      "gen",
+      "identity",
+      "integers",
+      "invariant",
+      "lazy",
+      "lists",
+      "machines",
+      "math",
+      "newtype",
+      "partial",
+      "prelude",
+      "profunctor",
+      "random",
+      "strings",
+      "tailrec",
+      "transformers",
+      "tuples"
+    ],
+    "repo": "https://github.com/purescript-contrib/purescript-strongcheck.git",
+    "version": "v5.0.0"
   },
   "struct": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1208,11 +1208,10 @@
       "prelude",
       "rationals",
       "strings",
-      "strongcheck",
       "tuples"
     ],
     "repo": "https://github.com/citizennet/purescript-fuzzy.git",
-    "version": "v0.2.1"
+    "version": "v0.3.0"
   },
   "gen": {
     "dependencies": [
@@ -1339,7 +1338,7 @@
       "halogen-hooks"
     ],
     "repo": "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git",
-    "version": "v0.3.0"
+    "version": "v0.4.0"
   },
   "halogen-select": {
     "dependencies": [
@@ -3391,39 +3390,6 @@
     ],
     "repo": "https://github.com/menelaos/purescript-stringutils.git",
     "version": "v0.0.10"
-  },
-  "strongcheck": {
-    "dependencies": [
-      "arrays",
-      "console",
-      "control",
-      "datetime",
-      "effect",
-      "either",
-      "enums",
-      "exceptions",
-      "foldable-traversable",
-      "free",
-      "gen",
-      "identity",
-      "integers",
-      "invariant",
-      "lazy",
-      "lists",
-      "machines",
-      "math",
-      "newtype",
-      "partial",
-      "prelude",
-      "profunctor",
-      "random",
-      "strings",
-      "tailrec",
-      "transformers",
-      "tuples"
-    ],
-    "repo": "https://github.com/purescript-contrib/purescript-strongcheck.git",
-    "version": "v5.0.0"
   },
   "struct": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1334,13 +1334,6 @@
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
     "version": "v0.2.0"
   },
-  "halogen-hooks-extra": {
-    "dependencies": [
-      "halogen-hooks"
-    ],
-    "repo": "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git",
-    "version": "v0.3.0"
-  },
   "halogen-select": {
     "dependencies": [
       "halogen",
@@ -3391,39 +3384,6 @@
     ],
     "repo": "https://github.com/menelaos/purescript-stringutils.git",
     "version": "v0.0.10"
-  },
-  "strongcheck": {
-    "dependencies": [
-      "arrays",
-      "console",
-      "control",
-      "datetime",
-      "effect",
-      "either",
-      "enums",
-      "exceptions",
-      "foldable-traversable",
-      "free",
-      "gen",
-      "identity",
-      "integers",
-      "invariant",
-      "lazy",
-      "lists",
-      "machines",
-      "math",
-      "newtype",
-      "partial",
-      "prelude",
-      "profunctor",
-      "random",
-      "strings",
-      "tailrec",
-      "transformers",
-      "tuples"
-    ],
-    "repo": "https://github.com/purescript-contrib/purescript-strongcheck.git",
-    "version": "v5.0.0"
   },
   "struct": {
     "dependencies": [

--- a/src/groups/citizennet.dhall
+++ b/src/groups/citizennet.dhall
@@ -8,11 +8,10 @@
     , "prelude"
     , "rationals"
     , "strings"
-    , "strongcheck"
     , "tuples"
     ]
   , repo = "https://github.com/citizennet/purescript-fuzzy.git"
-  , version = "v0.2.1"
+  , version = "v0.3.0"
   }
 , halogen-select =
   { dependencies = [ "halogen", "record" ]

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -2,7 +2,7 @@
   { dependencies = [ "halogen-hooks" ]
   , repo =
       "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git"
-  , version = "v0.3.0"
+  , version = "v0.4.0"
   }
 , interpolate =
   { dependencies = [ "prelude" ]

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -1,4 +1,10 @@
-{ interpolate =
+{ halogen-hooks-extra =
+  { dependencies = [ "halogen-hooks" ]
+  , repo =
+      "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git"
+  , version = "v0.3.0"
+  }
+, interpolate =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/jordanmartinez/purescript-interpolate.git"
   , version = "v2.0.1"

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -1,10 +1,4 @@
-{ halogen-hooks-extra =
-  { dependencies = [ "halogen-hooks" ]
-  , repo =
-      "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git"
-  , version = "v0.3.0"
-  }
-, interpolate =
+{ interpolate =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/jordanmartinez/purescript-interpolate.git"
   , version = "v2.0.1"

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -31,7 +31,7 @@
 , simple-i18n =
   { dependencies = [ "record-extra", "foreign-object" ]
   , repo = "https://github.com/oreshinya/purescript-simple-i18n.git"
-  , version = "v0.1.1"
+  , version = "v0.1.2"
   }
 , simple-jwt =
   { dependencies = [ "crypto", "simple-json", "strings" ]

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -247,7 +247,7 @@
     , "tuples"
     ]
   , repo = "https://github.com/purescript-contrib/purescript-strongcheck.git"
-  , version = "v4.1.1"
+  , version = "v5.0.0"
   }
 , these =
   { dependencies = [ "gen", "tuples" ]

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -216,39 +216,6 @@
   , repo = "https://github.com/purescript-contrib/purescript-strings-extra.git"
   , version = "v2.1.0"
   }
-, strongcheck =
-  { dependencies =
-    [ "arrays"
-    , "console"
-    , "control"
-    , "datetime"
-    , "effect"
-    , "either"
-    , "enums"
-    , "exceptions"
-    , "foldable-traversable"
-    , "free"
-    , "gen"
-    , "identity"
-    , "integers"
-    , "invariant"
-    , "lazy"
-    , "lists"
-    , "machines"
-    , "math"
-    , "newtype"
-    , "partial"
-    , "prelude"
-    , "profunctor"
-    , "random"
-    , "strings"
-    , "tailrec"
-    , "transformers"
-    , "tuples"
-    ]
-  , repo = "https://github.com/purescript-contrib/purescript-strongcheck.git"
-  , version = "v5.0.0"
-  }
 , these =
   { dependencies = [ "gen", "tuples" ]
   , repo = "https://github.com/purescript-contrib/purescript-these.git"

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -216,6 +216,39 @@
   , repo = "https://github.com/purescript-contrib/purescript-strings-extra.git"
   , version = "v2.1.0"
   }
+, strongcheck =
+  { dependencies =
+    [ "arrays"
+    , "console"
+    , "control"
+    , "datetime"
+    , "effect"
+    , "either"
+    , "enums"
+    , "exceptions"
+    , "foldable-traversable"
+    , "free"
+    , "gen"
+    , "identity"
+    , "integers"
+    , "invariant"
+    , "lazy"
+    , "lists"
+    , "machines"
+    , "math"
+    , "newtype"
+    , "partial"
+    , "prelude"
+    , "profunctor"
+    , "random"
+    , "strings"
+    , "tailrec"
+    , "transformers"
+    , "tuples"
+    ]
+  , repo = "https://github.com/purescript-contrib/purescript-strongcheck.git"
+  , version = "v5.0.0"
+  }
 , these =
   { dependencies = [ "gen", "tuples" ]
   , repo = "https://github.com/purescript-contrib/purescript-these.git"

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -10,7 +10,7 @@
     , "unsafe-reference"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v5.1.0"
+  , version = "v5.2.0"
   }
 , uuid =
   { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -12,7 +12,7 @@
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.1.0"
+  , version = "v0.2.0"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`halogen-hooks` upgraded to `v0.2.0`](https://github.com/thomashoneyman/purescript-halogen-hooks/releases/tag/v0.2.0)
- [`react-basic-hooks` upgraded to `v5.2.0`](https://github.com/spicydonuts/purescript-react-basic-hooks/releases/tag/v5.2.0)
- [`simple-i18n` upgraded to `v0.1.2`](https://github.com/oreshinya/purescript-simple-i18n/releases/tag/v0.1.2)
- [`strongcheck` upgraded to `v5.0.0`](https://github.com/purescript-contrib/purescript-strongcheck/releases/tag/v5.0.0)

Banned packages:
- `strongcheck`@`v4.1.1`

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
