### PR TITLE
Drop strongcheck

### DIFF
--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -216,39 +216,6 @@
   , repo = "https://github.com/purescript-contrib/purescript-strings-extra.git"
   , version = "v2.1.0"
   }
-, strongcheck =
-  { dependencies =
-    [ "arrays"
-    , "console"
-    , "control"
-    , "datetime"
-    , "effect"
-    , "either"
-    , "enums"
-    , "exceptions"
-    , "foldable-traversable"
-    , "free"
-    , "gen"
-    , "identity"
-    , "integers"
-    , "invariant"
-    , "lazy"
-    , "lists"
-    , "machines"
-    , "math"
-    , "newtype"
-    , "partial"
-    , "prelude"
-    , "profunctor"
-    , "random"
-    , "strings"
-    , "tailrec"
-    , "transformers"
-    , "tuples"
-    ]
-  , repo = "https://github.com/purescript-contrib/purescript-strongcheck.git"
-  , version = "v4.1.1"
-  }
 , these =
   { dependencies = [ "gen", "tuples" ]
   , repo = "https://github.com/purescript-contrib/purescript-these.git"


### PR DESCRIPTION
Strongcheck has [been deprecated](https://github.com/purescript-deprecated/purescript-strongcheck), so it probably ought to be dropped from package sets as well. All other -contrib deprecations were already not in package sets.

If this causes conflicts we can leave the package in the set until it goes out of date.