### PR TITLE
Updates 2020-05-02

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2800,7 +2800,7 @@
       "web-html"
     ],
     "repo": "https://github.com/lumihq/purescript-react-basic.git",
-    "version": "v13.0.0"
+    "version": "v14.0.0"
   },
   "react-basic-hooks": {
     "dependencies": [

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -14,6 +14,6 @@
     , "web-html"
     ]
   , repo = "https://github.com/lumihq/purescript-react-basic.git"
-  , version = "v13.0.0"
+  , version = "v14.0.0"
   }
 }


### PR DESCRIPTION
Updated packages:
- [`react-basic` upgraded to `v14.0.0`](https://github.com/lumihq/purescript-react-basic/releases/tag/v14.0.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
