### PR TITLE
Add `codec`, `codec-argonaut`, and `option`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -574,6 +574,14 @@
     "repo": "https://github.com/justinwoo/purescript-chocopie.git",
     "version": "v5.0.0"
   },
+  "codec": {
+    "dependencies": [
+      "profunctor",
+      "transformers"
+    ],
+    "repo": "https://github.com/garyb/purescript-codec.git",
+    "version": "v3.0.0"
+  },
   "colors": {
     "dependencies": [
       "arrays",

--- a/packages.json
+++ b/packages.json
@@ -582,6 +582,18 @@
     "repo": "https://github.com/garyb/purescript-codec.git",
     "version": "v3.0.0"
   },
+  "codec-argonaut": {
+    "dependencies": [
+      "argonaut-core",
+      "codec",
+      "generics-rep",
+      "ordered-collections",
+      "type-equality",
+      "variant"
+    ],
+    "repo": "https://github.com/garyb/purescript-codec-argonaut.git",
+    "version": "v7.1.0"
+  },
   "colors": {
     "dependencies": [
       "arrays",

--- a/packages.json
+++ b/packages.json
@@ -2279,6 +2279,29 @@
     "repo": "https://github.com/sharkdp/purescript-numbers.git",
     "version": "v7.0.0"
   },
+  "option": {
+    "dependencies": [
+      "argonaut-codecs",
+      "argonaut-core",
+      "codec",
+      "codec-argonaut",
+      "either",
+      "foreign",
+      "foreign-object",
+      "lists",
+      "maybe",
+      "prelude",
+      "profunctor",
+      "record",
+      "simple-json",
+      "transformers",
+      "tuples",
+      "type-equality",
+      "unsafe-coerce"
+    ],
+    "repo": "https://github.com/joneshf/purescript-option.git",
+    "version": "v1.0.0"
+  },
   "options": {
     "dependencies": [
       "contravariant",

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -3,6 +3,18 @@
   , repo = "https://github.com/garyb/purescript-codec.git"
   , version = "v3.0.0"
   }
+, codec-argonaut =
+  { dependencies =
+    [ "argonaut-core"
+    , "codec"
+    , "generics-rep"
+    , "ordered-collections"
+    , "type-equality"
+    , "variant"
+    ]
+  , repo = "https://github.com/garyb/purescript-codec-argonaut.git"
+  , version = "v7.1.0"
+  }
 , debug =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/garyb/purescript-debug.git"

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -1,4 +1,9 @@
-{ debug =
+{ codec =
+  { dependencies = [ "transformers", "profunctor" ]
+  , repo = "https://github.com/garyb/purescript-codec.git"
+  , version = "v3.0.0"
+  }
+, debug =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/garyb/purescript-debug.git"
   , version = "v4.0.0"

--- a/src/groups/joneshf.dhall
+++ b/src/groups/joneshf.dhall
@@ -1,0 +1,24 @@
+{ option =
+  { dependencies =
+    [ "argonaut-codecs"
+    , "argonaut-core"
+    , "codec"
+    , "codec-argonaut"
+    , "either"
+    , "foreign"
+    , "foreign-object"
+    , "lists"
+    , "maybe"
+    , "profunctor"
+    , "prelude"
+    , "record"
+    , "simple-json"
+    , "transformers"
+    , "tuples"
+    , "type-equality"
+    , "unsafe-coerce"
+    ]
+  , repo = "https://github.com/joneshf/purescript-option.git"
+  , version = "v1.0.0"
+  }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -5,6 +5,7 @@ let packages =
       ⫽ ./groups/purescript-node.dhall
       ⫽ ./groups/ad-si.dhall
       ⫽ ./groups/awakesecurity.dhall
+      ⫽ ./groups/joneshf.dhall
       ⫽ ./groups/liamgoodacre.dhall
       ⫽ ./groups/lukajcb.dhall
       ⫽ ./groups/michaelxavier.dhall


### PR DESCRIPTION
I wanted to add `purescript-option`, but it depends on `purescript-codec` and `purescript-codec-argonaut`. Added those as well. Would like to get confirmation from @garyb that it is okay to add these two packages.

Re: https://github.com/joneshf/purescript-option/issues/14