### PR TITLE
Updates 2020-05-04

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1387,7 +1387,7 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.2.0"
+    "version": "v0.2.1"
   },
   "halogen-hooks-extra": {
     "dependencies": [

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -12,7 +12,7 @@
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.2.0"
+  , version = "v0.2.1"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`halogen-hooks` upgraded to `v0.2.1`](https://github.com/thomashoneyman/purescript-halogen-hooks/releases/tag/v0.2.1)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
