### PR TITLE
Updates 2020-05-05

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1379,7 +1379,7 @@
       "variant"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-formless.git",
-    "version": "v1.0.0-rc.1"
+    "version": "v1.0.0-rc.2"
   },
   "halogen-hooks": {
     "dependencies": [

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -7,7 +7,7 @@
     , "profunctor-lenses"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-formless.git"
-  , version = "v1.0.0-rc.1"
+  , version = "v1.0.0-rc.2"
   }
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]


### PR DESCRIPTION
Updated packages:
- [`halogen-formless` upgraded to `v1.0.0-rc.2`](https://github.com/thomashoneyman/purescript-halogen-formless/releases/tag/v1.0.0-rc.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
