### PR TITLE
Updates 2020-05-08

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1387,7 +1387,7 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.2.1"
+    "version": "v0.3.0"
   },
   "halogen-hooks-extra": {
     "dependencies": [
@@ -2311,7 +2311,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/joneshf/purescript-option.git",
-    "version": "v1.0.0"
+    "version": "v1.0.2"
   },
   "options": {
     "dependencies": [

--- a/src/groups/joneshf.dhall
+++ b/src/groups/joneshf.dhall
@@ -19,6 +19,6 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/joneshf/purescript-option.git"
-  , version = "v1.0.0"
+  , version = "v1.0.2"
   }
 }

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -12,7 +12,7 @@
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.2.1"
+  , version = "v0.3.0"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`halogen-hooks` upgraded to `v0.3.0`](https://github.com/thomashoneyman/purescript-halogen-hooks/releases/tag/v0.3.0)
- [`option` upgraded to `v1.0.2`](https://github.com/joneshf/purescript-option/releases/tag/v1.0.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
