### PR TITLE
Updates 2020-05-09

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -110,7 +110,7 @@
       "record"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-argonaut-codecs.git",
-    "version": "v6.0.2"
+    "version": "v6.1.0"
   },
   "argonaut-core": {
     "dependencies": [

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -21,7 +21,7 @@
     ]
   , repo =
       "https://github.com/purescript-contrib/purescript-argonaut-codecs.git"
-  , version = "v6.0.2"
+  , version = "v6.1.0"
   }
 , argonaut-core =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`argonaut-codecs` upgraded to `v6.1.0`](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v6.1.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
