### PR TITLE
Updates 2020-05-10

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1208,7 +1208,7 @@
       "freedom"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom-virtualized.git",
-    "version": "v3.0.0"
+    "version": "v3.0.1"
   },
   "freedom-window-resize": {
     "dependencies": [

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -29,7 +29,7 @@
   { dependencies = [ "freedom" ]
   , repo =
       "https://github.com/purescript-freedom/purescript-freedom-virtualized.git"
-  , version = "v3.0.0"
+  , version = "v3.0.1"
   }
 , freedom-window-resize =
   { dependencies = [ "freedom" ]


### PR DESCRIPTION
Updated packages:
- [`freedom-virtualized` upgraded to `v3.0.1`](https://github.com/purescript-freedom/purescript-freedom-virtualized/releases/tag/v3.0.1)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
