### PR TITLE
Updates 2020-05-12

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -998,7 +998,7 @@
       "prelude"
     ],
     "repo": "https://github.com/athanclark/purescript-float32.git",
-    "version": "v0.1.1"
+    "version": "v0.2.0"
   },
   "flow-id": {
     "dependencies": [
@@ -1394,7 +1394,7 @@
       "halogen-hooks"
     ],
     "repo": "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git",
-    "version": "v0.5.0"
+    "version": "v0.5.1"
   },
   "halogen-select": {
     "dependencies": [
@@ -2563,7 +2563,7 @@
       "prelude"
     ],
     "repo": "https://github.com/gcanti/purescript-prettier.git",
-    "version": "v0.2.0"
+    "version": "v0.3.0"
   },
   "profunctor": {
     "dependencies": [

--- a/src/groups/athanclark.dhall
+++ b/src/groups/athanclark.dhall
@@ -29,7 +29,7 @@
 , float32 =
   { dependencies = [ "generics-rep", "prelude" ]
   , repo = "https://github.com/athanclark/purescript-float32.git"
-  , version = "v0.1.1"
+  , version = "v0.2.0"
   }
 , inflection =
   { dependencies = [ "functions" ]

--- a/src/groups/gcanti.dhall
+++ b/src/groups/gcanti.dhall
@@ -1,6 +1,6 @@
 { prettier =
   { dependencies = [ "maybe", "prelude" ]
   , repo = "https://github.com/gcanti/purescript-prettier.git"
-  , version = "v0.2.0"
+  , version = "v0.3.0"
   }
 }

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -2,7 +2,7 @@
   { dependencies = [ "halogen-hooks" ]
   , repo =
       "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git"
-  , version = "v0.5.0"
+  , version = "v0.5.1"
   }
 , interpolate =
   { dependencies = [ "prelude" ]


### PR DESCRIPTION
Updated packages:
- [`float32` upgraded to `v0.2.0`](https://github.com/athanclark/purescript-float32/releases/tag/v0.2.0)
- [`halogen-hooks-extra` upgraded to `v0.5.1`](https://github.com/jordanmartinez/purescript-halogen-hooks-extra/releases/tag/v0.5.1)
- [`prettier` upgraded to `v0.3.0`](https://github.com/gcanti/purescript-prettier/releases/tag/v0.3.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
