### PR TITLE
Updates 2020-05-16

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1387,14 +1387,14 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.3.0"
+    "version": "v0.4.0"
   },
   "halogen-hooks-extra": {
     "dependencies": [
       "halogen-hooks"
     ],
     "repo": "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git",
-    "version": "v0.5.1"
+    "version": "v0.6.0"
   },
   "halogen-select": {
     "dependencies": [
@@ -3509,7 +3509,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-strings.git",
-    "version": "v4.0.1"
+    "version": "v4.0.2"
   },
   "strings-extra": {
     "dependencies": [

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -2,7 +2,7 @@
   { dependencies = [ "halogen-hooks" ]
   , repo =
       "https://github.com/jordanmartinez/purescript-halogen-hooks-extra.git"
-  , version = "v0.5.1"
+  , version = "v0.6.0"
   }
 , interpolate =
   { dependencies = [ "prelude" ]

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -481,7 +481,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript/purescript-strings.git"
-  , version = "v4.0.1"
+  , version = "v4.0.2"
   }
 , tailrec =
   { dependencies =

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -12,7 +12,7 @@
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.3.0"
+  , version = "v0.4.0"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`halogen-hooks` upgraded to `v0.4.0`](https://github.com/thomashoneyman/purescript-halogen-hooks/releases/tag/v0.4.0)
- [`halogen-hooks-extra` upgraded to `v0.6.0`](https://github.com/jordanmartinez/purescript-halogen-hooks-extra/releases/tag/v0.6.0)
- [`strings` upgraded to `v4.0.2`](https://github.com/purescript/purescript-strings/releases/tag/v4.0.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
