### PR TITLE
Updates 2020-05-19

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1387,7 +1387,7 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.4.0"
+    "version": "v0.4.1"
   },
   "halogen-hooks-extra": {
     "dependencies": [
@@ -1402,7 +1402,7 @@
       "record"
     ],
     "repo": "https://github.com/citizennet/purescript-halogen-select.git",
-    "version": "v5.0.0-rc.4"
+    "version": "v5.0.0"
   },
   "halogen-storybook": {
     "dependencies": [
@@ -4047,7 +4047,7 @@
       "web-events"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-dom.git",
-    "version": "v4.0.1"
+    "version": "v4.0.2"
   },
   "web-events": {
     "dependencies": [

--- a/src/groups/citizennet.dhall
+++ b/src/groups/citizennet.dhall
@@ -16,6 +16,6 @@
 , halogen-select =
   { dependencies = [ "halogen", "record" ]
   , repo = "https://github.com/citizennet/purescript-halogen-select.git"
-  , version = "v5.0.0-rc.4"
+  , version = "v5.0.0"
   }
 }

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -12,7 +12,7 @@
 , web-dom =
   { dependencies = [ "web-events" ]
   , repo = "https://github.com/purescript-web/purescript-web-dom.git"
-  , version = "v4.0.1"
+  , version = "v4.0.2"
   }
 , web-events =
   { dependencies = [ "datetime", "enums", "nullable" ]

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -12,7 +12,7 @@
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.4.0"
+  , version = "v0.4.1"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`halogen-hooks` upgraded to `v0.4.1`](https://github.com/thomashoneyman/purescript-halogen-hooks/releases/tag/v0.4.1)
- [`halogen-select` upgraded to `v5.0.0`](https://github.com/citizennet/purescript-halogen-select/releases/tag/v5.0.0)
- [`web-dom` upgraded to `v4.0.2`](https://github.com/purescript-web/purescript-web-dom/releases/tag/v4.0.2)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
