### PR TITLE
Add tree-rose

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3784,6 +3784,15 @@
     "repo": "https://github.com/purescript/purescript-transformers.git",
     "version": "v4.2.0"
   },
+  "tree-rose": {
+    "dependencies": [
+      "free",
+      "lists",
+      "prelude"
+    ],
+    "repo": "https://github.com/jordanmartinez/purescript-tree-rose.git",
+    "version": "v2.0.0"
+  },
   "trout": {
     "dependencies": [
       "argonaut",

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -9,4 +9,9 @@
   , repo = "https://github.com/jordanmartinez/purescript-interpolate.git"
   , version = "v2.0.1"
   }
+, tree-rose =
+  { dependencies = [ "prelude", "lists", "free" ]
+  , repo = "https://github.com/jordanmartinez/purescript-tree-rose.git"
+  , version = "v2.0.0"
+  }
 }


### PR DESCRIPTION
`purescript-tree-rose` is a fork of the currently unmaintained `purescript-tree` library. `purescript-tree` isn't yet in the package set, but I created a new name that's more specific for what kind of tree this is. I also created a new repo rather than using my fork because I recall reading that some issues can arise with forked repos when the original repo is deleted or something. I'm not sure whether that is still true, but I thought "better safe than sorry."