### PR TITLE
purs 0.13.8, various package updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: nix
-script: nix-shell --run 'make ci'
+
+script:
+  - |
+    curl https://nixos.org/nix/install | sh
+    . "$HOME"/.nix-profile/etc/profile.d/nix.sh
+    nix-shell --run 'make ci'
+
 cache:
   directories:
   - .psc-package
   - output
+
 before_deploy:
   - nix-shell --run '>packages.dhall dhall <<< ./src/packages.dhall'
+
 deploy:
   provider: releases
   api_key: $RELEASE_KEY

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@ let
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
       repo = "easy-purescript-nix";
-      rev = "340e82b6ecaccc4059740e69f8ec18546b527481";
-      sha256 = "1q2ciwd3193kig1paidzrgxl60y4rb39bsi97lk7m6ff8mis6z6i";
+      rev = "0ba91d9aa9f7421f6bfe4895677159a8a999bf20";
+      sha256 = "1baq7mmd3vjas87f0gzlq83n2l1h3dlqajjqr7fgaazpa9xgzs7q";
     }
   ) {
     inherit pkgs;
@@ -15,8 +15,8 @@ let
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
       repo = "easy-dhall-nix";
-      rev = "35bca5ba56b7b3f8684aa0afbb65608159beb5ce";
-      sha256 = "16l71qzzfkv4sbxl03r291nswsrkr3g13viqkma2s8r5vy9la3al";
+      rev = "62f6ab3eec5a2c0bf62f604f48cd15465b10023a";
+      sha256 = "07lvvc3yvjy6ji3z320f467n485hzwwa9ldwi6zylxcb6a2jb7i0";
     }
   ) {
     inherit pkgs;

--- a/packages.json
+++ b/packages.json
@@ -78,7 +78,7 @@
       "web-xhr"
     ],
     "repo": "https://github.com/slamdata/purescript-affjax.git",
-    "version": "v10.0.0"
+    "version": "v10.1.0"
   },
   "ansi": {
     "dependencies": [
@@ -1179,7 +1179,7 @@
       "web-html"
     ],
     "repo": "https://github.com/purescript-freedom/purescript-freedom.git",
-    "version": "v2.1.0"
+    "version": "v2.2.0"
   },
   "freedom-now": {
     "dependencies": [
@@ -1355,7 +1355,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen.git",
-    "version": "v5.0.0-rc.9"
+    "version": "v5.0.1"
   },
   "halogen-bootstrap": {
     "dependencies": [
@@ -1396,7 +1396,7 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.4.1"
+    "version": "v0.4.2"
   },
   "halogen-hooks-extra": {
     "dependencies": [
@@ -1895,7 +1895,7 @@
   "metadata": {
     "dependencies": [],
     "repo": "https://github.com/spacchetti/purescript-metadata.git",
-    "version": "v0.13.6"
+    "version": "v0.13.8"
   },
   "milkis": {
     "dependencies": [
@@ -2320,7 +2320,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/joneshf/purescript-option.git",
-    "version": "v1.0.2"
+    "version": "v2.1.0"
   },
   "options": {
     "dependencies": [
@@ -4078,7 +4078,7 @@
       "web-events"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-dom.git",
-    "version": "v4.0.2"
+    "version": "v4.1.0"
   },
   "web-events": {
     "dependencies": [

--- a/src/groups/joneshf.dhall
+++ b/src/groups/joneshf.dhall
@@ -19,6 +19,6 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/joneshf/purescript-option.git"
-  , version = "v1.0.2"
+  , version = "v2.1.0"
   }
 }

--- a/src/groups/purescript-freedom.dhall
+++ b/src/groups/purescript-freedom.dhall
@@ -2,7 +2,7 @@
   { dependencies =
     [ "console", "foreign-object", "safely", "simple-emitter", "web-html" ]
   , repo = "https://github.com/purescript-freedom/purescript-freedom.git"
-  , version = "v2.1.0"
+  , version = "v2.2.0"
   }
 , freedom-now =
   { dependencies = [ "freedom", "js-timers" ]

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -12,7 +12,7 @@
 , web-dom =
   { dependencies = [ "web-events" ]
   , repo = "https://github.com/purescript-web/purescript-web-dom.git"
-  , version = "v4.0.2"
+  , version = "v4.1.0"
   }
 , web-events =
   { dependencies = [ "datetime", "enums", "nullable" ]

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -39,7 +39,7 @@
     , "web-xhr"
     ]
   , repo = "https://github.com/slamdata/purescript-affjax.git"
-  , version = "v10.0.0"
+  , version = "v10.1.0"
   }
 , css =
   { dependencies =
@@ -108,7 +108,7 @@
     , "web-uievents"
     ]
   , repo = "https://github.com/slamdata/purescript-halogen.git"
-  , version = "v5.0.0-rc.9"
+  , version = "v5.0.1"
   }
 , halogen-bootstrap =
   { dependencies = [ "halogen" ]

--- a/src/groups/spacchetti.dhall
+++ b/src/groups/spacchetti.dhall
@@ -1,6 +1,6 @@
 { metadata =
   { dependencies = [] : List Text
   , repo = "https://github.com/spacchetti/purescript-metadata.git"
-  , version = "v0.13.6"
+  , version = "v0.13.8"
   }
 }

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -12,7 +12,7 @@
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.4.1"
+  , version = "v0.4.2"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Updated packages:
- [`affjax` upgraded to `v10.1.0`](https://github.com/slamdata/purescript-affjax/releases/tag/v10.1.0)
- [`data-default` upgraded to `0.1.0`](https://github.com/dancingrobot84/purescript-data-default/releases/tag/0.1.0)
- [`freedom` upgraded to `v2.2.0`](https://github.com/purescript-freedom/purescript-freedom/releases/tag/v2.2.0)
- [`halogen` upgraded to `v5.0.1`](https://github.com/slamdata/purescript-halogen/releases/tag/v5.0.1)
- [`halogen-hooks` upgraded to `v0.4.2`](https://github.com/thomashoneyman/purescript-halogen-hooks/releases/tag/v0.4.2)
- [`metadata` upgraded to `v0.13.8`](https://github.com/spacchetti/purescript-metadata/releases/tag/v0.13.8)
- [`option` upgraded to `v2.1.0`](https://github.com/joneshf/purescript-option/releases/tag/v2.1.0)
- [`web-dom` upgraded to `v4.1.0`](https://github.com/purescript-web/purescript-web-dom/releases/tag/v4.1.0)

You can give commands to the bot by adding a comment where you tag it, e.g.:
- `@spacchettibotti ban react-basic`
- `@spacchettibotti unban simple-json`
