### PR TITLE
Merge master with kl0tl/es-modules, then run `nix-shell --command make`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -38,8 +38,8 @@
       "avar",
       "prelude"
     ],
-    "repo": "https://github.com/slamdata/purescript-aff-bus.git",
-    "version": "v4.0.0"
+    "repo": "https://github.com/kl0tl/purescript-aff-bus.git",
+    "version": "roles-declarations"
   },
   "aff-coroutines": {
     "dependencies": [
@@ -194,7 +194,7 @@
       "uint"
     ],
     "repo": "https://github.com/jacereda/purescript-arraybuffer.git",
-    "version": "v10.0.2"
+    "version": "polykindsupdate"
   },
   "arraybuffer-class": {
     "dependencies": [
@@ -212,7 +212,7 @@
   "arraybuffer-types": {
     "dependencies": [],
     "repo": "https://github.com/purescript-contrib/purescript-arraybuffer-types.git",
-    "version": "v2.0.0"
+    "version": "ps-0.14"
   },
   "arrays": {
     "dependencies": [
@@ -230,7 +230,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-arrays.git",
-    "version": "v5.3.1"
+    "version": "master"
   },
   "arrays-zipper": {
     "dependencies": [
@@ -245,8 +245,8 @@
       "effect",
       "prelude"
     ],
-    "repo": "https://github.com/purescript/purescript-assert.git",
-    "version": "v4.1.0"
+    "repo": "https://github.com/kl0tl/purescript-assert.git",
+    "version": "no-foreign-primes"
   },
   "avar": {
     "dependencies": [
@@ -313,7 +313,7 @@
       "strings"
     ],
     "repo": "https://github.com/sharkdp/purescript-bigints.git",
-    "version": "v4.0.0"
+    "version": "master"
   },
   "bip39": {
     "dependencies": [
@@ -466,8 +466,8 @@
       "media-types",
       "simple-json"
     ],
-    "repo": "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git",
-    "version": "v3.0.0"
+    "repo": "https://github.com/jordanmartinez/purescript-bucketchain-simple-api.git",
+    "version": "polykindsUpdate"
   },
   "bucketchain-sslify": {
     "dependencies": [
@@ -576,26 +576,6 @@
     ],
     "repo": "https://github.com/icyrockcom/purescript-cheerio.git",
     "version": "v0.2.3"
-  },
-  "chirashi": {
-    "dependencies": [
-      "exceptions",
-      "prelude",
-      "typelevel-prelude",
-      "variant"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-chirashi.git",
-    "version": "v1.0.0"
-  },
-  "choco-pie": {
-    "dependencies": [
-      "event",
-      "prelude",
-      "record",
-      "typelevel-prelude"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-chocopie.git",
-    "version": "v5.0.0"
   },
   "clipboardy": {
     "dependencies": [
@@ -802,7 +782,7 @@
       "maybe"
     ],
     "repo": "https://github.com/sharkdp/purescript-decimals.git",
-    "version": "v5.0.0"
+    "version": "master"
   },
   "distributive": {
     "dependencies": [
@@ -1116,7 +1096,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/purescript/purescript-foreign-object.git",
-    "version": "v2.0.3"
+    "version": "ps-0.14"
   },
   "fork": {
     "dependencies": [
@@ -1409,7 +1389,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen.git",
-    "version": "v5.0.1"
+    "version": "master"
   },
   "halogen-bootstrap": {
     "dependencies": [
@@ -1442,7 +1422,7 @@
       "variant"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-formless.git",
-    "version": "v1.0.0-rc.2"
+    "version": "master"
   },
   "halogen-hooks": {
     "dependencies": [
@@ -1513,8 +1493,8 @@
       "tuples",
       "variant"
     ],
-    "repo": "https://github.com/natefaubion/purescript-heterogeneous.git",
-    "version": "v0.4.1"
+    "repo": "https://github.com/jordanmartinez/purescript-heterogeneous.git",
+    "version": "polykindsUpdate"
   },
   "higher-order": {
     "dependencies": [
@@ -1660,8 +1640,8 @@
     "dependencies": [
       "simple-json"
     ],
-    "repo": "https://github.com/oreshinya/purescript-identy.git",
-    "version": "v2.1.0"
+    "repo": "https://github.com/jordanmartinez/purescript-identy.git",
+    "version": "polykindsUpdate"
   },
   "indexed-monad": {
     "dependencies": [
@@ -1669,7 +1649,7 @@
       "newtype"
     ],
     "repo": "https://github.com/garyb/purescript-indexed-monad.git",
-    "version": "v1.2.0"
+    "version": "ps-0.14"
   },
   "inflection": {
     "dependencies": [
@@ -1719,15 +1699,6 @@
     "repo": "https://github.com/purescript/purescript-invariant.git",
     "version": "v4.1.0"
   },
-  "jajanmen": {
-    "dependencies": [
-      "node-sqlite3",
-      "prelude",
-      "typelevel-prelude"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-jajanmen.git",
-    "version": "v1.0.0"
-  },
   "jquery": {
     "dependencies": [
       "console",
@@ -1736,7 +1707,7 @@
       "web-dom"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-jquery.git",
-    "version": "v5.0.0"
+    "version": "master"
   },
   "js-date": {
     "dependencies": [
@@ -1777,7 +1748,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/felixmulder/purescript-json-schema.git",
-    "version": "v0.0.1"
+    "version": "master"
   },
   "jwt": {
     "dependencies": [
@@ -1793,26 +1764,6 @@
     ],
     "repo": "https://github.com/menelaos/purescript-jwt.git",
     "version": "v0.0.7"
-  },
-  "kancho": {
-    "dependencies": [
-      "foreign",
-      "newtype",
-      "strings",
-      "typelevel-prelude"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-kancho.git",
-    "version": "v2.0.0"
-  },
-  "kishimen": {
-    "dependencies": [
-      "generics-rep",
-      "prelude",
-      "typelevel-prelude",
-      "variant"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-kishimen.git",
-    "version": "v1.0.1"
   },
   "lazy": {
     "dependencies": [
@@ -2086,15 +2037,7 @@
       "simple-json"
     ],
     "repo": "https://github.com/oreshinya/purescript-mysql.git",
-    "version": "v4.1.1"
-  },
-  "naporitan": {
-    "dependencies": [
-      "record",
-      "typelevel-prelude"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-naporitan.git",
-    "version": "v1.0.0"
+    "version": "master"
   },
   "naturals": {
     "dependencies": [
@@ -2121,7 +2064,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript-node/purescript-node-buffer.git",
-    "version": "v6.0.0"
+    "version": "master"
   },
   "node-child-process": {
     "dependencies": [
@@ -2192,7 +2135,7 @@
   "node-he": {
     "dependencies": [],
     "repo": "https://github.com/justinwoo/purescript-node-he.git",
-    "version": "v0.2.0"
+    "version": "master"
   },
   "node-http": {
     "dependencies": [
@@ -2252,7 +2195,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/epost/purescript-node-postgres.git",
-    "version": "v5.0.0"
+    "version": "master"
   },
   "node-process": {
     "dependencies": [
@@ -2517,7 +2460,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/slamdata/purescript-pathy.git",
-    "version": "v7.0.1"
+    "version": "ps-0.14"
   },
   "phoenix": {
     "dependencies": [
@@ -2562,8 +2505,8 @@
       "validation",
       "variant"
     ],
-    "repo": "https://github.com/paluh/purescript-polyform.git",
-    "version": "v0.8.2"
+    "repo": "https://github.com/jordanmartinez/purescript-polyform.git",
+    "version": "master"
   },
   "posix-types": {
     "dependencies": [
@@ -2600,7 +2543,7 @@
   "prelude": {
     "dependencies": [],
     "repo": "https://github.com/purescript/purescript-prelude.git",
-    "version": "v4.1.1"
+    "version": "ps-0.14"
   },
   "prettier": {
     "dependencies": [
@@ -2677,8 +2620,8 @@
       "prelude",
       "typelevel-prelude"
     ],
-    "repo": "https://github.com/matthew-hilty/purescript-proxying.git",
-    "version": "v1.1.0"
+    "repo": "https://github.com/jordanmartinez/purescript-proxying.git",
+    "version": "polykindsUpdate"
   },
   "psa-utils": {
     "dependencies": [
@@ -2756,7 +2699,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/Dretch/purescript-querydsl.git",
-    "version": "v0.10.1"
+    "version": "ps-0.14"
   },
   "queue": {
     "dependencies": [
@@ -2887,8 +2830,8 @@
       "typelevel-prelude",
       "unsafe-coerce"
     ],
-    "repo": "https://github.com/purescript-contrib/purescript-react.git",
-    "version": "v8.0.0"
+    "repo": "https://github.com/kl0tl/purescript-react.git",
+    "version": "roles-declarations"
   },
   "react-basic": {
     "dependencies": [
@@ -2963,24 +2906,15 @@
   "react-basic-hooks": {
     "dependencies": [
       "aff",
-      "aff-promise",
       "console",
-      "datetime",
       "effect",
-      "either",
       "indexed-monad",
-      "maybe",
-      "newtype",
-      "numbers",
       "prelude",
       "react-basic",
-      "type-equality",
-      "unsafe-coerce",
-      "unsafe-reference",
-      "web-html"
+      "unsafe-reference"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v6.0.0"
+    "version": "main"
   },
   "react-basic-native": {
     "dependencies": [
@@ -3049,8 +2983,8 @@
       "st",
       "unsafe-coerce"
     ],
-    "repo": "https://github.com/purescript/purescript-record.git",
-    "version": "v2.0.2"
+    "repo": "https://github.com/kl0tl/purescript-record.git",
+    "version": "psc-0.14.0"
   },
   "record-extra": {
     "dependencies": [
@@ -3061,7 +2995,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-record-extra.git",
-    "version": "v3.0.1"
+    "version": "ps-0.14"
   },
   "record-format": {
     "dependencies": [
@@ -3069,8 +3003,8 @@
       "strings",
       "typelevel-prelude"
     ],
-    "repo": "https://github.com/kcsongor/purescript-record-format.git",
-    "version": "v2.0.0"
+    "repo": "https://github.com/jordanmartinez/purescript-record-format.git",
+    "version": "polykindsUpdate"
   },
   "redis-client": {
     "dependencies": [
@@ -3133,7 +3067,7 @@
       "prelude"
     ],
     "repo": "https://github.com/purescript/purescript-refs.git",
-    "version": "v4.1.0"
+    "version": "master"
   },
   "remotedata": {
     "dependencies": [
@@ -3196,8 +3130,8 @@
       "strings",
       "typelevel-prelude"
     ],
-    "repo": "https://github.com/natefaubion/purescript-routing-duplex.git",
-    "version": "v0.4.1"
+    "repo": "https://github.com/jordanmartinez/purescript-routing-duplex.git",
+    "version": "polykindsUpdate"
   },
   "row-extra": {
     "dependencies": [],
@@ -3322,14 +3256,6 @@
     "repo": "https://github.com/athanclark/purescript-setimmediate.git",
     "version": "v1.0.2"
   },
-  "shoronpo": {
-    "dependencies": [
-      "prelude",
-      "record-format"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-shoronpo.git",
-    "version": "v0.3.0"
-  },
   "signal": {
     "dependencies": [
       "aff",
@@ -3338,17 +3264,8 @@
       "maybe",
       "prelude"
     ],
-    "repo": "https://github.com/bodil/purescript-signal.git",
-    "version": "v10.1.0"
-  },
-  "sijidou": {
-    "dependencies": [
-      "prelude",
-      "record",
-      "typelevel-prelude"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-sijidou.git",
-    "version": "v1.0.0"
+    "repo": "https://github.com/kl0tl/purescript-signal.git",
+    "version": "no-foreign-primes"
   },
   "simple-ajax": {
     "dependencies": [
@@ -3372,8 +3289,8 @@
       "foreign-object",
       "record-extra"
     ],
-    "repo": "https://github.com/oreshinya/purescript-simple-i18n.git",
-    "version": "v0.1.2"
+    "repo": "https://github.com/jordanmartinez/purescript-simple-i18n.git",
+    "version": "polykindsUpdate"
   },
   "simple-json": {
     "dependencies": [
@@ -3389,7 +3306,7 @@
       "variant"
     ],
     "repo": "https://github.com/justinwoo/purescript-simple-json.git",
-    "version": "v7.0.0"
+    "version": "ps-0.14"
   },
   "simple-json-generics": {
     "dependencies": [
@@ -3615,8 +3532,8 @@
       "tailrec",
       "unsafe-coerce"
     ],
-    "repo": "https://github.com/purescript/purescript-st.git",
-    "version": "v4.1.1"
+    "repo": "https://github.com/kl0tl/purescript-st.git",
+    "version": "no-foreign-primes"
   },
   "string-parsers": {
     "dependencies": [
@@ -3654,7 +3571,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-strings.git",
-    "version": "v4.0.2"
+    "version": "master"
   },
   "strings-extra": {
     "dependencies": [
@@ -3694,8 +3611,8 @@
       "subcategory",
       "variant"
     ],
-    "repo": "https://github.com/matthew-hilty/purescript-struct.git",
-    "version": "v1.1.0"
+    "repo": "https://github.com/jordanmartinez/purescript-struct.git",
+    "version": "polykindsUpdate"
   },
   "stylesheet": {
     "dependencies": [
@@ -3879,23 +3796,6 @@
     "repo": "https://github.com/justinwoo/purescript-toppokki.git",
     "version": "v2.4.0"
   },
-  "tortellini": {
-    "dependencies": [
-      "foreign-object",
-      "integers",
-      "lists",
-      "motsunabe",
-      "numbers",
-      "prelude",
-      "record",
-      "string-parsers",
-      "strings",
-      "transformers",
-      "typelevel-prelude"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-tortellini.git",
-    "version": "v5.1.0"
-  },
   "transformers": {
     "dependencies": [
       "control",
@@ -3980,7 +3880,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-type-isequal.git",
-    "version": "v0.1.0"
+    "version": "ps-0.14"
   },
   "typedenv": {
     "dependencies": [
@@ -3993,7 +3893,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/nsaunders/purescript-typedenv.git",
-    "version": "v0.0.1"
+    "version": "ps-0.14"
   },
   "typelevel": {
     "dependencies": [
@@ -4026,7 +3926,7 @@
       "type-equality"
     ],
     "repo": "https://github.com/purescript/purescript-typelevel-prelude.git",
-    "version": "v5.0.2"
+    "version": "ps-0.14"
   },
   "typelevel-rowlist-limits": {
     "dependencies": [
@@ -4107,7 +4007,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/fehrenbach/purescript-unordered-collections.git",
-    "version": "v1.8.3"
+    "version": "master"
   },
   "unorm": {
     "dependencies": [],
@@ -4175,8 +4075,8 @@
       "tuples",
       "unsafe-coerce"
     ],
-    "repo": "https://github.com/natefaubion/purescript-variant.git",
-    "version": "v6.0.1"
+    "repo": "https://github.com/kl0tl/purescript-variant.git",
+    "version": "psc-0.14.0"
   },
   "vectorfield": {
     "dependencies": [
@@ -4229,7 +4129,7 @@
       "web-storage"
     ],
     "repo": "https://github.com/purescript-web/purescript-web-html.git",
-    "version": "v2.3.0"
+    "version": "master"
   },
   "web-socket": {
     "dependencies": [
@@ -4296,13 +4196,6 @@
     ],
     "repo": "https://github.com/athanclark/purescript-websocket-moderate.git",
     "version": "v7.0.2"
-  },
-  "xiaomian": {
-    "dependencies": [
-      "naporitan"
-    ],
-    "repo": "https://github.com/justinwoo/purescript-xiaomian.git",
-    "version": "v0.1.0"
   },
   "yargs": {
     "dependencies": [

--- a/src/groups/bodil.dhall
+++ b/src/groups/bodil.dhall
@@ -1,8 +1,8 @@
 { signal =
   { dependencies =
     [ "aff", "foldable-traversable", "js-timers", "maybe", "prelude" ]
-  , repo = "https://github.com/bodil/purescript-signal.git"
-  , version = "v10.1.0"
+  , repo = "https://github.com/kl0tl/purescript-signal.git"
+  , version = "no-foreign-primes"
   }
 , sized-vectors =
   { dependencies =

--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -56,8 +56,8 @@
 , bucketchain-simple-api =
   { dependencies = [ "bucketchain", "media-types", "simple-json", "freet" ]
   , repo =
-      "https://github.com/Bucketchain/purescript-bucketchain-simple-api.git"
-  , version = "v3.0.0"
+      "https://github.com/jordanmartinez/purescript-bucketchain-simple-api.git"
+  , version = "polykindsUpdate"
   }
 , bucketchain-sslify =
   { dependencies = [ "bucketchain" ]

--- a/src/groups/dretch.dhall
+++ b/src/groups/dretch.dhall
@@ -17,6 +17,6 @@
     , "nullable"
     ]
   , repo = "https://github.com/Dretch/purescript-querydsl.git"
-  , version = "v0.10.1"
+  , version = "ps-0.14"
   }
 }

--- a/src/groups/epost.dhall
+++ b/src/groups/epost.dhall
@@ -13,6 +13,6 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/epost/purescript-node-postgres.git"
-  , version = "v5.0.0"
+  , version = "master"
   }
 }

--- a/src/groups/fehrenbach.dhall
+++ b/src/groups/fehrenbach.dhall
@@ -10,6 +10,6 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/fehrenbach/purescript-unordered-collections.git"
-  , version = "v1.8.3"
+  , version = "master"
   }
 }

--- a/src/groups/felixmulder.dhall
+++ b/src/groups/felixmulder.dhall
@@ -1,6 +1,6 @@
 { json-schema =
   { dependencies = [ "generics-rep", "prelude", "simple-json" ]
   , repo = "https://github.com/felixmulder/purescript-json-schema.git"
-  , version = "v0.0.1"
+  , version = "master"
   }
 }

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -23,7 +23,7 @@
 , indexed-monad =
   { dependencies = [ "control", "newtype" ]
   , repo = "https://github.com/garyb/purescript-indexed-monad.git"
-  , version = "v1.2.0"
+  , version = "ps-0.14"
   }
 , quickcheck-laws =
   { dependencies = [ "enums", "proxy", "quickcheck" ]

--- a/src/groups/jacereda.dhall
+++ b/src/groups/jacereda.dhall
@@ -12,6 +12,6 @@
     , "uint"
     ]
   , repo = "https://github.com/jacereda/purescript-arraybuffer.git"
-  , version = "v10.0.2"
+  , version = "polykindsupdate"
   }
 }

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -1,14 +1,4 @@
-{ chirashi =
-  { dependencies = [ "exceptions", "prelude", "typelevel-prelude", "variant" ]
-  , repo = "https://github.com/justinwoo/purescript-chirashi.git"
-  , version = "v1.0.0"
-  }
-, choco-pie =
-  { dependencies = [ "event", "prelude", "record", "typelevel-prelude" ]
-  , repo = "https://github.com/justinwoo/purescript-chocopie.git"
-  , version = "v5.0.0"
-  }
-, expect-inferred =
+{ expect-inferred =
   { dependencies = [ "prelude", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-expect-inferred.git"
   , version = "v2.0.0"
@@ -22,21 +12,6 @@
   { dependencies = [ "console", "effect", "prelude", "record", "web-html" ]
   , repo = "https://github.com/justinwoo/purescript-gomtang-basic.git"
   , version = "v0.2.0"
-  }
-, jajanmen =
-  { dependencies = [ "node-sqlite3", "prelude", "typelevel-prelude" ]
-  , repo = "https://github.com/justinwoo/purescript-jajanmen.git"
-  , version = "v1.0.0"
-  }
-, kancho =
-  { dependencies = [ "foreign", "newtype", "strings", "typelevel-prelude" ]
-  , repo = "https://github.com/justinwoo/purescript-kancho.git"
-  , version = "v2.0.0"
-  }
-, kishimen =
-  { dependencies = [ "generics-rep", "prelude", "typelevel-prelude", "variant" ]
-  , repo = "https://github.com/justinwoo/purescript-kishimen.git"
-  , version = "v1.0.1"
   }
 , lenient-html-parser =
   { dependencies = [ "console", "generics-rep", "prelude", "string-parsers" ]
@@ -64,15 +39,10 @@
   , repo = "https://github.com/justinwoo/purescript-motsunabe.git"
   , version = "v2.0.0"
   }
-, naporitan =
-  { dependencies = [ "record", "typelevel-prelude" ]
-  , repo = "https://github.com/justinwoo/purescript-naporitan.git"
-  , version = "v1.0.0"
-  }
 , node-he =
   { dependencies = [] : List Text
   , repo = "https://github.com/justinwoo/purescript-node-he.git"
-  , version = "v0.2.0"
+  , version = "master"
   }
 , node-sqlite3 =
   { dependencies = [ "aff", "foreign" ]
@@ -88,22 +58,12 @@
   { dependencies =
     [ "arrays", "functions", "lists", "record", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-record-extra.git"
-  , version = "v3.0.1"
+  , version = "ps-0.14"
   }
 , redux-devtools =
   { dependencies = [ "effect", "foreign", "nullable", "prelude" ]
   , repo = "https://github.com/justinwoo/purescript-redux-devtools.git"
   , version = "v0.1.0"
-  }
-, shoronpo =
-  { dependencies = [ "prelude", "record-format" ]
-  , repo = "https://github.com/justinwoo/purescript-shoronpo.git"
-  , version = "v0.3.0"
-  }
-, sijidou =
-  { dependencies = [ "prelude", "record", "typelevel-prelude" ]
-  , repo = "https://github.com/justinwoo/purescript-sijidou.git"
-  , version = "v1.0.0"
   }
 , simple-json =
   { dependencies =
@@ -119,7 +79,7 @@
     , "variant"
     ]
   , repo = "https://github.com/justinwoo/purescript-simple-json.git"
-  , version = "v7.0.0"
+  , version = "ps-0.14"
   }
 , simple-json-generics =
   { dependencies = [ "generics-rep", "simple-json" ]
@@ -148,31 +108,9 @@
   , repo = "https://github.com/justinwoo/purescript-toppokki.git"
   , version = "v2.4.0"
   }
-, tortellini =
-  { dependencies =
-    [ "foreign-object"
-    , "integers"
-    , "lists"
-    , "motsunabe"
-    , "numbers"
-    , "prelude"
-    , "record"
-    , "string-parsers"
-    , "strings"
-    , "transformers"
-    , "typelevel-prelude"
-    ]
-  , repo = "https://github.com/justinwoo/purescript-tortellini.git"
-  , version = "v5.1.0"
-  }
 , type-isequal =
   { dependencies = [ "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-type-isequal.git"
-  , version = "v0.1.0"
-  }
-, xiaomian =
-  { dependencies = [ "naporitan" ]
-  , repo = "https://github.com/justinwoo/purescript-xiaomian.git"
-  , version = "v0.1.0"
+  , version = "ps-0.14"
   }
 }

--- a/src/groups/kcsongor.dhall
+++ b/src/groups/kcsongor.dhall
@@ -1,6 +1,6 @@
 { record-format =
   { dependencies = [ "record", "strings", "typelevel-prelude" ]
-  , repo = "https://github.com/kcsongor/purescript-record-format.git"
-  , version = "v2.0.0"
+  , repo = "https://github.com/jordanmartinez/purescript-record-format.git"
+  , version = "polykindsUpdate"
   }
 }

--- a/src/groups/matthew-hilty.dhall
+++ b/src/groups/matthew-hilty.dhall
@@ -15,8 +15,8 @@
   }
 , proxying =
   { dependencies = [ "effect", "generics-rep", "prelude", "typelevel-prelude" ]
-  , repo = "https://github.com/matthew-hilty/purescript-proxying.git"
-  , version = "v1.1.0"
+  , repo = "https://github.com/jordanmartinez/purescript-proxying.git"
+  , version = "polykindsUpdate"
   }
 , struct =
   { dependencies =
@@ -29,8 +29,8 @@
     , "subcategory"
     , "variant"
     ]
-  , repo = "https://github.com/matthew-hilty/purescript-struct.git"
-  , version = "v1.1.0"
+  , repo = "https://github.com/jordanmartinez/purescript-struct.git"
+  , version = "polykindsUpdate"
   }
 , subcategory =
   { dependencies =

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -11,8 +11,8 @@
 , heterogeneous =
   { dependencies =
     [ "either", "functors", "prelude", "record", "tuples", "variant" ]
-  , repo = "https://github.com/natefaubion/purescript-heterogeneous.git"
-  , version = "v0.4.1"
+  , repo = "https://github.com/jordanmartinez/purescript-heterogeneous.git"
+  , version = "polykindsUpdate"
   }
 , psa-utils =
   { dependencies =
@@ -50,8 +50,8 @@
     , "strings"
     , "typelevel-prelude"
     ]
-  , repo = "https://github.com/natefaubion/purescript-routing-duplex.git"
-  , version = "v0.4.1"
+  , repo = "https://github.com/jordanmartinez/purescript-routing-duplex.git"
+  , version = "polykindsUpdate"
   }
 , run =
   { dependencies =
@@ -113,7 +113,7 @@
     , "tuples"
     , "unsafe-coerce"
     ]
-  , repo = "https://github.com/natefaubion/purescript-variant.git"
-  , version = "v6.0.1"
+  , repo = "https://github.com/kl0tl/purescript-variant.git"
+  , version = "psc-0.14.0"
   }
 }

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -30,6 +30,6 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/nsaunders/purescript-typedenv.git"
-  , version = "v0.0.1"
+  , version = "ps-0.14"
   }
 }

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -10,13 +10,13 @@
   }
 , identy =
   { dependencies = [ "simple-json" ]
-  , repo = "https://github.com/oreshinya/purescript-identy.git"
-  , version = "v2.1.0"
+  , repo = "https://github.com/jordanmartinez/purescript-identy.git"
+  , version = "polykindsUpdate"
   }
 , mysql =
   { dependencies = [ "aff", "js-date", "simple-json" ]
   , repo = "https://github.com/oreshinya/purescript-mysql.git"
-  , version = "v4.1.1"
+  , version = "master"
   }
 , nodemailer =
   { dependencies = [ "aff", "node-streams", "simple-json" ]
@@ -30,8 +30,8 @@
   }
 , simple-i18n =
   { dependencies = [ "record-extra", "foreign-object" ]
-  , repo = "https://github.com/oreshinya/purescript-simple-i18n.git"
-  , version = "v0.1.2"
+  , repo = "https://github.com/jordanmartinez/purescript-simple-i18n.git"
+  , version = "polykindsUpdate"
   }
 , simple-jwt =
   { dependencies = [ "crypto", "simple-json", "strings" ]

--- a/src/groups/paluh.dhall
+++ b/src/groups/paluh.dhall
@@ -23,8 +23,8 @@
     , "validation"
     , "variant"
     ]
-  , repo = "https://github.com/paluh/purescript-polyform.git"
-  , version = "v0.8.2"
+  , repo = "https://github.com/jordanmartinez/purescript-polyform.git"
+  , version = "master"
   }
 , redis-client =
   { dependencies =

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -60,7 +60,7 @@
   { dependencies = [] : List Text
   , repo =
       "https://github.com/purescript-contrib/purescript-arraybuffer-types.git"
-  , version = "v2.0.0"
+  , version = "ps-0.14"
   }
 , coroutines =
   { dependencies = [ "freet", "parallel", "profunctor" ]
@@ -106,7 +106,7 @@
 , jquery =
   { dependencies = [ "console", "effect", "foreign", "web-dom" ]
   , repo = "https://github.com/purescript-contrib/purescript-jquery.git"
-  , version = "v5.0.0"
+  , version = "master"
   }
 , machines =
   { dependencies =
@@ -197,8 +197,8 @@
     , "typelevel-prelude"
     , "unsafe-coerce"
     ]
-  , repo = "https://github.com/purescript-contrib/purescript-react.git"
-  , version = "v8.0.0"
+  , repo = "https://github.com/kl0tl/purescript-react.git"
+  , version = "roles-declarations"
   }
 , react-dom =
   { dependencies = [ "effect", "react", "web-dom" ]

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -2,7 +2,7 @@
   { dependencies =
     [ "arraybuffer-types", "effect", "maybe", "st", "unsafe-coerce" ]
   , repo = "https://github.com/purescript-node/purescript-node-buffer.git"
-  , version = "v6.0.0"
+  , version = "master"
   }
 , node-child-process =
   { dependencies =

--- a/src/groups/purescript-web.dhall
+++ b/src/groups/purescript-web.dhall
@@ -27,7 +27,7 @@
 , web-html =
   { dependencies = [ "js-date", "web-dom", "web-file", "web-storage" ]
   , repo = "https://github.com/purescript-web/purescript-web-html.git"
-  , version = "v2.3.0"
+  , version = "master"
   }
 , web-socket =
   { dependencies = [ "arraybuffer-types", "web-file" ]

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -14,12 +14,12 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript/purescript-arrays.git"
-  , version = "v5.3.1"
+  , version = "master"
   }
 , assert =
   { dependencies = [ "console", "effect", "prelude" ]
-  , repo = "https://github.com/purescript/purescript-assert.git"
-  , version = "v4.1.0"
+  , repo = "https://github.com/kl0tl/purescript-assert.git"
+  , version = "no-foreign-primes"
   }
 , bifunctors =
   { dependencies = [ "newtype", "prelude" ]
@@ -172,7 +172,7 @@
     , "unfoldable"
     ]
   , repo = "https://github.com/purescript/purescript-foreign-object.git"
-  , version = "v2.0.3"
+  , version = "ps-0.14"
   }
 , free =
   { dependencies =
@@ -375,7 +375,7 @@
 , prelude =
   { dependencies = [] : List Text
   , repo = "https://github.com/purescript/purescript-prelude.git"
-  , version = "v4.1.1"
+  , version = "ps-0.14"
   }
 , profunctor =
   { dependencies =
@@ -443,13 +443,13 @@
   }
 , record =
   { dependencies = [ "functions", "prelude", "st", "unsafe-coerce" ]
-  , repo = "https://github.com/purescript/purescript-record.git"
-  , version = "v2.0.2"
+  , repo = "https://github.com/kl0tl/purescript-record.git"
+  , version = "psc-0.14.0"
   }
 , refs =
   { dependencies = [ "effect", "prelude" ]
   , repo = "https://github.com/purescript/purescript-refs.git"
-  , version = "v4.1.0"
+  , version = "master"
   }
 , semirings =
   { dependencies = [ "foldable-traversable", "lists", "newtype", "prelude" ]
@@ -458,8 +458,8 @@
   }
 , st =
   { dependencies = [ "partial", "prelude", "tailrec", "unsafe-coerce" ]
-  , repo = "https://github.com/purescript/purescript-st.git"
-  , version = "v4.1.1"
+  , repo = "https://github.com/kl0tl/purescript-st.git"
+  , version = "no-foreign-primes"
   }
 , strings =
   { dependencies =
@@ -481,7 +481,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript/purescript-strings.git"
-  , version = "v4.0.2"
+  , version = "master"
   }
 , tailrec =
   { dependencies =
@@ -540,7 +540,7 @@
 , typelevel-prelude =
   { dependencies = [ "prelude", "proxy", "type-equality" ]
   , repo = "https://github.com/purescript/purescript-typelevel-prelude.git"
-  , version = "v5.0.2"
+  , version = "ps-0.14"
   }
 , unfoldable =
   { dependencies =

--- a/src/groups/sharkdp.dhall
+++ b/src/groups/sharkdp.dhall
@@ -1,7 +1,7 @@
 { bigints =
   { dependencies = [ "integers", "maybe", "strings" ]
   , repo = "https://github.com/sharkdp/purescript-bigints.git"
-  , version = "v4.0.0"
+  , version = "master"
   }
 , colors =
   { dependencies = [ "arrays", "integers", "lists", "partial", "strings" ]
@@ -11,7 +11,7 @@
 , decimals =
   { dependencies = [ "maybe" ]
   , repo = "https://github.com/sharkdp/purescript-decimals.git"
-  , version = "v5.0.0"
+  , version = "master"
   }
 , flare =
   { dependencies =

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -26,8 +26,8 @@
   }
 , aff-bus =
   { dependencies = [ "avar", "prelude" ]
-  , repo = "https://github.com/slamdata/purescript-aff-bus.git"
-  , version = "v4.0.0"
+  , repo = "https://github.com/kl0tl/purescript-aff-bus.git"
+  , version = "roles-declarations"
   }
 , avar =
   { dependencies =
@@ -121,7 +121,7 @@
     , "web-uievents"
     ]
   , repo = "https://github.com/slamdata/purescript-halogen.git"
-  , version = "v5.0.1"
+  , version = "master"
   }
 , halogen-bootstrap =
   { dependencies = [ "halogen" ]
@@ -163,7 +163,7 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/slamdata/purescript-pathy.git"
-  , version = "v7.0.1"
+  , version = "ps-0.14"
   }
 , routing =
   { dependencies =

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -1,24 +1,15 @@
 { react-basic-hooks =
   { dependencies =
-    [ "prelude"
-    , "aff-promise"
-    , "aff"
+    [ "aff"
     , "console"
-    , "datetime"
     , "effect"
-    , "either"
     , "indexed-monad"
-    , "maybe"
-    , "newtype"
-    , "numbers"
+    , "prelude"
     , "react-basic"
-    , "type-equality"
-    , "unsafe-coerce"
     , "unsafe-reference"
-    , "web-html"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v6.0.0"
+  , version = "main"
   }
 , uuid =
   { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -7,7 +7,7 @@
     , "profunctor-lenses"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-formless.git"
-  , version = "v1.0.0-rc.2"
+  , version = "master"
   }
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]


### PR DESCRIPTION
When merging, I checked most packages to see whether the repo and/or version a package uses in the es-modules branch is significantly different from the current master. If it was, I defaulted to the `prepare-0.14` branch, even when I know it's not compatible with 0.14.0, rather than the es-modules' branch's change. This will require additional work on our part before this package set compiles. However, it means bugs and other important changes won't be removed from those libraries.

Using the current `master` branch for `purescript`, I ran `rm -rf .stack-work/` and then ran `stack build`. I copied the resulting binary over to this repo on my computer. Then I ran `../purs compile ".spago/*/*/src/**/*.purs"`

Here are the current 13 errors. I'm sure there are more, but it's hard to say until we get more of the code to compile:
```
Error 1 of 13:

  in module Data.Argonaut.Decode.Class
  at .spago/argonaut-codecs/v7.0.0/src/Data/Argonaut/Decode/Class.purs:103:44 - 103:54 (line 103, column 44 - line 103, column 54)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type synonym GDecodeJson$Dict

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 2 of 13:

  in module Data.Argonaut.Encode.Class
  at .spago/argonaut-codecs/v7.0.0/src/Data/Argonaut/Encode/Class.purs:101:44 - 101:54 (line 101, column 44 - line 101, column 54)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type synonym GEncodeJson$Dict

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 3 of 13:

  in module Data.Codec.Argonaut.Record
  at .spago/codec-argonaut/v7.1.0/src/Data/Codec/Argonaut/Record.purs:43:26 - 43:36 (line 43, column 26 - line 43, column 36)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type synonym RowListCodec$Dict

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 4 of 13:

  in module Data.Codec.Argonaut.Variant
  at .spago/codec-argonaut/v7.1.0/src/Data/Codec/Argonaut/Variant.purs:131:26 - 131:36 (line 131, column 26 - line 131, column 36)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type synonym VariantCodec$Dict

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 5 of 13:

  in module Data.Default
  at .spago/data-default/v0.3.2/src/Data/Default.purs:48:40 - 48:50 (line 48, column 40 - line 48, column 50)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type synonym GDefault$Dict

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 6 of 13:

  in module Data.Finance.Currency
  at .spago/money/v8.0.0/src/Data/Finance/Currency.purs:7:1 - 9:30 (line 7, column 1 - line 9, column 30)

    Declaration for type class Currency conflicts with an existing type of the same name.


  See https://github.com/purescript/documentation/blob/master/errors/DeclConflict.md for more information,
  or to contribute content related to this error.

Error 7 of 13:

  in module Data.Tuple.Native
  at .spago/tuples-native/v2.1.0/src/Data/Tuple/Native.purs:97:25 - 97:32 (line 97, column 25 - line 97, column 32)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type synonym TupleSize$Dict

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 8 of 13:

  in module Effect.Aff.Bus
  at .spago/aff-bus/roles-declarations/src/Effect/Aff/Bus.purs:48:1 - 48:64 (line 48, column 1 - line 48, column 64)

    Role mismatch for the type parameter a:

      The annotation says representational but the role nominal is required.


  in role declaration for Bus
  in type constructor Bus

  See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
  or to contribute content related to this error.

Error 9 of 13:

  in module Formless.Action
  at .spago/halogen-formless/master/src/Formless/Action.purs:234:38 - 234:56 (line 234, column 38 - line 234, column 56)

    No type class instance was found for
                                                              
      Data.Newtype.Newtype (form5 Record (InputField @t6 @t7))
                           (Record is'8)                      
                                                              
    The instance head contains unknown type variables. Consider adding a type annotation.

  while applying a function wrapInputFields
    of type Newtype (t0 Record (InputField @t1 @t2)) (Record t3) => HMap WrapField (Record t4) (Record t3) => Record t4 -> t0 Record (InputField @t1 @t2)
    to argument is
  while inferring the type of wrapInputFields is
  in value declaration setValidateAll

  where form5 is a rigid type variable
          bound at (line 0, column 0 - line 0, column 0)
        is'8 is a rigid type variable
          bound at (line 0, column 0 - line 0, column 0)
        t1 is an unknown type
        t2 is an unknown type
        t0 is an unknown type
        t4 is an unknown type
        t3 is an unknown type
        t6 is an unknown type
        t7 is an unknown type

  See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
  or to contribute content related to this error.

Error 10 of 13:

  in module Formless.Internal.Transform
  at .spago/halogen-formless/master/src/Formless/Internal/Transform.purs:257:38 - 257:48 (line 257, column 38 - line 257, column 48)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type class declaration for InputFieldsToFormFields

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 11 of 13:

  in module React.Basic.Events
  at .spago/react-basic/v15.0.0/src/React/Basic/Events.purs:82:20 - 82:27 (line 82, column 20 - line 82, column 27)

    Could not match kind
                  
      Type -> Type
                  
    with kind
          
      Type
          

  while checking that type RowList
    has kind Type
  in type class declaration for Merge

  See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
  or to contribute content related to this error.

Error 12 of 13:

  in module React.Basic.Hooks.Internal
  at .spago/react-basic-hooks/main/src/React/Basic/Hooks/Internal.purs:129:5 - 129:39 (line 129, column 5 - line 129, column 39)

    Cannot unambiguously generalize kinds appearing in the elaborated type:

      forall (hooks :: t22). Render @t22 @t22 hooks hooks a

    where t22 is an unknown kind.
    Try adding additional kind signatures or polymorphic kind variables.

  in type synonym Pure

  See https://github.com/purescript/documentation/blob/master/errors/QuantificationCheckFailureInType.md for more information,
  or to contribute content related to this error.

Error 13 of 13:

  in module Type.Data.Peano.Nat.Definition
  at .spago/typelevel-peano/v0.1.8/src/Type/Data/Peano/Nat/Definition.purs:4:49 - 4:61 (line 4, column 49 - line 4, column 61)

    Cannot import type Boolean from module Type.Prelude
    It either does not exist or the module does not export it.


  See https://github.com/purescript/documentation/blob/master/errors/UnknownImport.md for more information,
  or to contribute content related to this error.
```
There are 470 warnings. I skimmed through the warnings and estimated the following stats:
- 66%: "The inferred kind for the `some type thing here` contains polymorphic kinds. Consider adding a top-level kind signature as a form of documentation." 
- 28%: "Unary '#' syntax for row kinds is deprecated and will be removed in a future release. Use the 'Row' kind instead."
- 5%: "Name `name` was shadowed."
- 1%: miscellaneous other warnings