### PR TITLE
Add hoodunit/payload

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2579,6 +2579,28 @@
     "repo": "https://github.com/slamdata/purescript-pathy.git",
     "version": "v7.0.1"
   },
+  "payload": {
+    "dependencies": [
+      "aff",
+      "affjax",
+      "console",
+      "debug",
+      "effect",
+      "foreign-generic",
+      "node-fs",
+      "node-fs-aff",
+      "node-http",
+      "prelude",
+      "psci-support",
+      "record",
+      "simple-json",
+      "stringutils",
+      "test-unit",
+      "typelevel-prelude"
+    ],
+    "repo": "https://github.com/hoodunit/purescript-payload",
+    "version": "v0.3.0"
+  },
   "phoenix": {
     "dependencies": [
       "options"

--- a/src/groups/hoodunit.dhall
+++ b/src/groups/hoodunit.dhall
@@ -1,0 +1,23 @@
+{ payload =
+  { dependencies =
+    [ "aff"
+    , "affjax"
+    , "console"
+    , "debug"
+    , "effect"
+    , "foreign-generic"
+    , "node-fs"
+    , "node-fs-aff"
+    , "node-http"
+    , "prelude"
+    , "psci-support"
+    , "record"
+    , "simple-json"
+    , "stringutils"
+    , "test-unit"
+    , "typelevel-prelude"
+    ]
+  , repo = "https://github.com/hoodunit/purescript-payload"
+  , version = "v0.3.0"
+  }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -32,6 +32,7 @@ let packages =
       ⫽ ./groups/garyb.dhall
       ⫽ ./groups/gcanti.dhall
       ⫽ ./groups/hdgarrood.dhall
+      ⫽ ./groups/hoodunit.dhall
       ⫽ ./groups/hrajchert.dhall
       ⫽ ./groups/i-am-tom.dhall
       ⫽ ./groups/icyrockcom.dhall


### PR DESCRIPTION
This PR adds https://github.com/hoodunit/purescript-payload, a strongly typed HTTP backend.