### PR TITLE
Add packages from zudov

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4289,6 +4289,15 @@
     "repo": "https://github.com/purescript/purescript-validation.git",
     "version": "v4.2.0"
   },
+  "var": {
+    "dependencies": [
+      "contravariant",
+      "effect",
+      "invariant"
+    ],
+    "repo": "https://github.com/zudov/purescript-var.git",
+    "version": "v3.0.0"
+  },
   "variant": {
     "dependencies": [
       "enums",
@@ -4422,6 +4431,18 @@
     ],
     "repo": "https://github.com/athanclark/purescript-websocket-moderate.git",
     "version": "v7.0.2"
+  },
+  "websocket-simple": {
+    "dependencies": [
+      "effect",
+      "exceptions",
+      "generics-rep",
+      "var",
+      "web-events",
+      "web-socket"
+    ],
+    "repo": "https://github.com/zudov/purescript-websocket-simple.git",
+    "version": "v3.0.1"
   },
   "xiaomian": {
     "dependencies": [

--- a/src/groups/zudov.dhall
+++ b/src/groups/zudov.dhall
@@ -1,0 +1,18 @@
+{ websocket-simple =
+  { dependencies =
+    [ "web-socket"
+    , "web-events"
+    , "effect"
+    , "exceptions"
+    , "generics-rep"
+    , "var"
+    ]
+  , repo = "https://github.com/zudov/purescript-websocket-simple.git"
+  , version = "v3.0.1"
+  }
+, var =
+  { dependencies = [ "effect", "contravariant", "invariant" ]
+  , repo = "https://github.com/zudov/purescript-var.git"
+  , version = "v3.0.0"
+  }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -95,5 +95,6 @@ let packages =
       ⫽ ./groups/markfarrell.dhall
       ⫽ ./groups/lukasturcani.dhall
       ⫽ ./groups/iarthstar.dhall
+      ⫽ ./groups/zudov.dhall
 
 in  packages


### PR DESCRIPTION
This PR adds the `websocket-simple` and `var` packages by @zudov. They are already published on Bower and this adds them to the package sets as well.