### PR TITLE
Update to latest Dhall standard

### DIFF
--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -16,7 +16,7 @@
   , repo = "https://github.com/purescript/purescript-arrays.git"
   , version = "v5.3.1"
   }
-, assert =
+, `assert` =
   { dependencies = [ "console", "effect", "prelude" ]
   , repo = "https://github.com/purescript/purescript-assert.git"
   , version = "v4.1.0"


### PR DESCRIPTION
`assert` is now a reserved work, so this fails on the latest Dhall:

```
$ dhall <<< '{ assert = 42 }'

dhall: 
Error: Invalid input

(input):1:3:
  |
1 | { assert = 42 }
  |   ^
unexpected 'a'
expecting ',', =, whitespace, or }
```

But this works (using the "extended label syntax"):

```
$ dhall <<< '{ `assert` = 42 }'

{ `assert` = 42 }
```