### PR TITLE
Update github-actions-toolkit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1494,7 +1494,7 @@
       "transformers"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-github-actions-toolkit",
-    "version": "v0.1.0"
+    "version": "v0.2.0"
   },
   "gl-matrix": {
     "dependencies": [

--- a/src/groups/colinwahl.dhall
+++ b/src/groups/colinwahl.dhall
@@ -12,6 +12,6 @@
     ]
   , repo =
       "https://github.com/purescript-contrib/purescript-github-actions-toolkit"
-  , version = "v0.1.0"
+  , version = "v0.2.0"
   }
 }


### PR DESCRIPTION
This bumps the github-actions-toolkit version from 0.1.0 to 0.2.0.