### PR TITLE
Prepare 0.14

### DIFF
--- a/src/groups/bucketchain.dhall
+++ b/src/groups/bucketchain.dhall
@@ -53,6 +53,8 @@
   , repo = "https://github.com/Bucketchain/purescript-bucketchain-secure.git"
   , version = "v0.1.0"
   }
+
+{- TODO: does not compile -}
 , bucketchain-simple-api =
   { dependencies = [ "bucketchain", "media-types", "simple-json", "freet" ]
   , repo =

--- a/src/groups/dretch.dhall
+++ b/src/groups/dretch.dhall
@@ -1,22 +1,25 @@
 { querydsl =
-  { dependencies =
-    [ "prelude"
-    , "effect"
-    , "arrays"
-    , "lists"
-    , "record"
-    , "strings"
-    , "tuples"
-    , "typelevel-prelude"
-    , "either"
-    , "transformers"
-    , "node-sqlite3"
-    , "datetime"
-    , "formatters"
-    , "node-buffer"
-    , "nullable"
-    ]
-  , repo = "https://github.com/Dretch/purescript-querydsl.git"
-  , version = "v0.10.1"
-  }
+    { dependencies =
+      [ "prelude"
+      , "effect"
+      , "arrays"
+      , "lists"
+      , "record"
+      , "strings"
+      , "tuples"
+      , "typelevel-prelude"
+      , "either"
+      , "transformers"
+      , "node-sqlite3"
+      , "datetime"
+      , "formatters"
+      , "node-buffer"
+      , "nullable"
+      ]
+    , repo = "https://github.com/Dretch/purescript-querydsl.git"
+    {- TODO: Not latest version, but only commits made since then
+       have been updating JS dependencies
+    -}
+    , version = "ps-0.14"
+    }
 }

--- a/src/groups/fehrenbach.dhall
+++ b/src/groups/fehrenbach.dhall
@@ -1,15 +1,19 @@
 { unordered-collections =
-  { dependencies =
-    [ "enums"
-    , "functions"
-    , "integers"
-    , "lists"
-    , "prelude"
-    , "record"
-    , "tuples"
-    , "typelevel-prelude"
-    ]
-  , repo = "https://github.com/fehrenbach/purescript-unordered-collections.git"
-  , version = "v1.8.3"
-  }
+    { dependencies =
+      [ "enums"
+      , "functions"
+      , "integers"
+      , "lists"
+      , "prelude"
+      , "record"
+      , "tuples"
+      , "typelevel-prelude"
+      ]
+    , repo =
+        "https://github.com/fehrenbach/purescript-unordered-collections.git"
+    {- TODO: in kl0tli's fork, role declarations were added. These
+       are not included in this branch
+    -}
+    , version = "master"
+    }
 }

--- a/src/groups/felixmulder.dhall
+++ b/src/groups/felixmulder.dhall
@@ -1,6 +1,9 @@
 { json-schema =
-  { dependencies = [ "generics-rep", "prelude", "simple-json" ]
-  , repo = "https://github.com/felixmulder/purescript-json-schema.git"
-  , version = "v0.0.1"
-  }
+    { dependencies = [ "generics-rep", "prelude", "simple-json" ]
+    , repo = "https://github.com/felixmulder/purescript-json-schema.git"
+    {- TODO: this version includes the commits I made that originally made
+       this repo compatible with PS v0.14 before more changes were made.
+    -}
+    , version = "master"
+    }
 }

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -21,10 +21,14 @@
   , version = "v4.0.0"
   }
 , indexed-monad =
-  { dependencies = [ "control", "newtype" ]
-  , repo = "https://github.com/garyb/purescript-indexed-monad.git"
-  , version = "v1.2.0"
-  }
+    { dependencies = [ "control", "newtype" ]
+    , repo = "https://github.com/garyb/purescript-indexed-monad.git"
+    {- TODO: this repo will need to updated for PS v0.14 by merging
+      its ps-0.14 branch into master, which includes a few extra commits
+      that ps-0.14 does not include.
+    -}
+    , version = "master"
+    }
 , quickcheck-laws =
   { dependencies = [ "enums", "proxy", "quickcheck" ]
   , repo = "https://github.com/garyb/purescript-quickcheck-laws.git"

--- a/src/groups/jacereda.dhall
+++ b/src/groups/jacereda.dhall
@@ -12,6 +12,10 @@
     , "uint"
     ]
   , repo = "https://github.com/jacereda/purescript-arraybuffer.git"
-  , version = "v10.0.2"
+  {- TODO: using master since latest release seems to break SemVer conventions.
+      This repo will need the polykindsupdate branch merged into master branch
+      to become compatible
+  -}
+  , version = "master"
   }
 }

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -1,4 +1,8 @@
-{ chirashi =
+{
+{-
+  TODO: these were ignored originally per Justin's comments
+  in the original Discourse thread Jordan made
+  chirashi =
   { dependencies = [ "exceptions", "prelude", "typelevel-prelude", "variant" ]
   , repo = "https://github.com/justinwoo/purescript-chirashi.git"
   , version = "v1.0.0"
@@ -8,7 +12,9 @@
   , repo = "https://github.com/justinwoo/purescript-chocopie.git"
   , version = "v5.0.0"
   }
-, expect-inferred =
+,
+-}
+  expect-inferred =
   { dependencies = [ "prelude", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-expect-inferred.git"
   , version = "v2.0.0"
@@ -23,6 +29,10 @@
   , repo = "https://github.com/justinwoo/purescript-gomtang-basic.git"
   , version = "v0.2.0"
   }
+
+{-
+  TODO: these were ignored originally per Justin's comments
+  in the original Discourse thread Jordan made
 , jajanmen =
   { dependencies = [ "node-sqlite3", "prelude", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-jajanmen.git"
@@ -38,6 +48,7 @@
   , repo = "https://github.com/justinwoo/purescript-kishimen.git"
   , version = "v1.0.1"
   }
+-}
 , lenient-html-parser =
   { dependencies = [ "console", "generics-rep", "prelude", "string-parsers" ]
   , repo = "https://github.com/justinwoo/purescript-lenient-html-parser.git"
@@ -64,11 +75,16 @@
   , repo = "https://github.com/justinwoo/purescript-motsunabe.git"
   , version = "v2.0.0"
   }
+
+{-
+  TODO: these were ignored originally per Justin's comments
+  in the original Discourse thread Jordan made
 , naporitan =
   { dependencies = [ "record", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-naporitan.git"
   , version = "v1.0.0"
   }
+-}
 , node-he =
   { dependencies = [] : List Text
   , repo = "https://github.com/justinwoo/purescript-node-he.git"
@@ -88,13 +104,19 @@
   { dependencies =
     [ "arrays", "functions", "lists", "record", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-record-extra.git"
-  , version = "v3.0.1"
+  {- TODO: ps-0.14 includes `master` and builds directly on top of it. -}
+  , version = "ps-0.14"
   }
 , redux-devtools =
   { dependencies = [ "effect", "foreign", "nullable", "prelude" ]
   , repo = "https://github.com/justinwoo/purescript-redux-devtools.git"
   , version = "v0.1.0"
   }
+
+{-
+  TODO: these were ignored originally per Justin's comments
+  in the original Discourse thread Jordan made
+
 , shoronpo =
   { dependencies = [ "prelude", "record-format" ]
   , repo = "https://github.com/justinwoo/purescript-shoronpo.git"
@@ -105,6 +127,8 @@
   , repo = "https://github.com/justinwoo/purescript-sijidou.git"
   , version = "v1.0.0"
   }
+
+-}
 , simple-json =
   { dependencies =
     [ "arrays"
@@ -119,7 +143,10 @@
     , "variant"
     ]
   , repo = "https://github.com/justinwoo/purescript-simple-json.git"
-  , version = "v7.0.0"
+  {- TODO: ps-0.14 should be merged into current `master` branch as
+     changes since ps-0.14 are mainly administrative
+  -}
+  , version = "master"
   }
 , simple-json-generics =
   { dependencies = [ "generics-rep", "simple-json" ]
@@ -168,11 +195,20 @@
 , type-isequal =
   { dependencies = [ "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-type-isequal.git"
-  , version = "v0.1.0"
+  {- TODO: this version builds directly on top of master -}
+  , version = "ps-0.14"
   }
+
+{-
+
+TODO: these were ignored originally per Justin's comments
+in the original Discourse thread Jordan made
+
 , xiaomian =
   { dependencies = [ "naporitan" ]
   , repo = "https://github.com/justinwoo/purescript-xiaomian.git"
   , version = "v0.1.0"
   }
+
+-}
 }

--- a/src/groups/kcsongor.dhall
+++ b/src/groups/kcsongor.dhall
@@ -1,6 +1,7 @@
 { record-format =
   { dependencies = [ "record", "strings", "typelevel-prelude" ]
   , repo = "https://github.com/kcsongor/purescript-record-format.git"
+  {- TODO: my fork's polykindsupdate branch should be merged into this repo's master branch -}
   , version = "v2.0.0"
   }
 }

--- a/src/groups/lumihq.dhall
+++ b/src/groups/lumihq.dhall
@@ -1,3 +1,6 @@
+{- TODO: These were broken up across multiple repos since my previous attempt 
+   I'll have to look at these later.
+-}
 { react-basic =
   { dependencies = [ "prelude", "effect", "record" ]
   , repo = "https://github.com/lumihq/purescript-react-basic.git"

--- a/src/groups/matthew-hilty.dhall
+++ b/src/groups/matthew-hilty.dhall
@@ -16,6 +16,7 @@
 , proxying =
   { dependencies = [ "effect", "generics-rep", "prelude", "typelevel-prelude" ]
   , repo = "https://github.com/matthew-hilty/purescript-proxying.git"
+  {- TODO: my fork's polykindsupdate can be merged into master -}
   , version = "v1.1.0"
   }
 , struct =
@@ -30,6 +31,7 @@
     , "variant"
     ]
   , repo = "https://github.com/matthew-hilty/purescript-struct.git"
+  {- TODO: my fork's polykindsupdate can be merged into master -}
   , version = "v1.1.0"
   }
 , subcategory =
@@ -51,6 +53,7 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/matthew-hilty/purescript-tolerant-argonaut.git"
+  {- TODO: my fork's polykindsupdate can be merged into master -}
   , version = "v2.0.0"
   }
 }

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -12,6 +12,7 @@
   { dependencies =
     [ "either", "functors", "prelude", "record", "tuples", "variant" ]
   , repo = "https://github.com/natefaubion/purescript-heterogeneous.git"
+  {- TODO: my fork's polykindsupdate can be merged into master -}
   , version = "v0.4.1"
   }
 , psa-utils =
@@ -51,6 +52,7 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/natefaubion/purescript-routing-duplex.git"
+  {- TODO: my fork's polykindsupdate can be merged into master -}
   , version = "v0.4.1"
   }
 , run =
@@ -114,6 +116,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/natefaubion/purescript-variant.git"
+  {- TODO: kl0tli's psc-0.14.0 branch should be merged into master -}
   , version = "v6.0.1"
   }
 }

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -30,6 +30,6 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/nsaunders/purescript-typedenv.git"
-  , version = "v0.0.1"
+  , version = "ps-0.14"
   }
 }

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -11,6 +11,7 @@
 , identy =
   { dependencies = [ "simple-json" ]
   , repo = "https://github.com/oreshinya/purescript-identy.git"
+  { TODO: merge kl0tli's psc-0.14.0 branch into master -}
   , version = "v2.2.0"
   }
 , mysql =
@@ -31,7 +32,10 @@
 , simple-i18n =
   { dependencies = [ "record-extra", "foreign-object" ]
   , repo = "https://github.com/oreshinya/purescript-simple-i18n.git"
-  , version = "v0.1.2"
+  {- TODO: merge my fork's polykindsupdate branch into master and
+    troubleshoot any issues
+  -}
+  , version = "master"
   }
 , simple-jwt =
   { dependencies = [ "crypto", "simple-json", "strings" ]

--- a/src/groups/oreshinya.dhall
+++ b/src/groups/oreshinya.dhall
@@ -11,7 +11,7 @@
 , identy =
   { dependencies = [ "simple-json" ]
   , repo = "https://github.com/oreshinya/purescript-identy.git"
-  { TODO: merge kl0tli's psc-0.14.0 branch into master -}
+  {- TODO: merge kl0tli's psc-0.14.0 branch into master -}
   , version = "v2.2.0"
   }
 , mysql =

--- a/src/groups/paluh.dhall
+++ b/src/groups/paluh.dhall
@@ -24,6 +24,7 @@
     , "variant"
     ]
   , repo = "https://github.com/paluh/purescript-polyform.git"
+  { TODO: need to manually make library compatible again. Too many changes since last attempt -}
   , version = "v0.8.2"
   }
 , redis-client =

--- a/src/groups/paluh.dhall
+++ b/src/groups/paluh.dhall
@@ -24,7 +24,7 @@
     , "variant"
     ]
   , repo = "https://github.com/paluh/purescript-polyform.git"
-  { TODO: need to manually make library compatible again. Too many changes since last attempt -}
+  {- TODO: need to manually make library compatible again. Too many changes since last attempt -}
   , version = "v0.8.2"
   }
 , redis-client =

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -24,6 +24,7 @@
     ]
   , repo =
       "https://github.com/purescript-contrib/purescript-argonaut-codecs.git"
+  {- TODO: make repo compatible again; too many changes since last attempt -}
   , version = "v7.0.0"
   }
 , argonaut-core =
@@ -60,6 +61,7 @@
   { dependencies = [] : List Text
   , repo =
       "https://github.com/purescript-contrib/purescript-arraybuffer-types.git"
+  {- TODO: merge the ps-0.14 branch into master branch -}
   , version = "v2.0.0"
   }
 , coroutines =
@@ -204,6 +206,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript-contrib/purescript-react.git"
+  {- TODO: merge kl0tli's roles-declarations branch into master -}
   , version = "v8.0.0"
   }
 , react-dom =

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -378,7 +378,7 @@
 , prelude =
   { dependencies = [] : List Text
   , repo = "https://github.com/purescript/purescript-prelude.git"
-  , version = "v4.1.1"
+  , version = "master"
   }
 , profunctor =
   { dependencies =

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -14,11 +14,13 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript/purescript-arrays.git"
+  {- TODO: merge kl0tli's roles-declarations into master -}
   , version = "v5.3.1"
   }
 , `assert` =
   { dependencies = [ "console", "effect", "prelude" ]
   , repo = "https://github.com/purescript/purescript-assert.git"
+  {- TODO: merge kl0tli's no-foreign-primes into master -}
   , version = "v4.1.0"
   }
 , bifunctors =
@@ -172,6 +174,7 @@
     , "unfoldable"
     ]
   , repo = "https://github.com/purescript/purescript-foreign-object.git"
+  {- TODO: merge kl0tli's roles-declarations into master -}
   , version = "v2.0.3"
   }
 , free =
@@ -444,6 +447,7 @@
 , record =
   { dependencies = [ "functions", "prelude", "st", "unsafe-coerce" ]
   , repo = "https://github.com/purescript/purescript-record.git"
+  {- TODO: merge kl0tli's psc-0.14.0 branch into master -}
   , version = "v2.0.2"
   }
 , refs =
@@ -459,6 +463,7 @@
 , st =
   { dependencies = [ "partial", "prelude", "tailrec", "unsafe-coerce" ]
   , repo = "https://github.com/purescript/purescript-st.git"
+  {- TODO: merge kl0tli's no-foreign-primes AND roles-declarations into master -}
   , version = "v4.1.1"
   }
 , strings =
@@ -540,6 +545,7 @@
 , typelevel-prelude =
   { dependencies = [ "prelude", "proxy", "type-equality" ]
   , repo = "https://github.com/purescript/purescript-typelevel-prelude.git"
+  {- TODO: merge my fok's ps-0.14 branch into master -}
   , version = "v5.0.2"
   }
 , unfoldable =

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -27,6 +27,7 @@
 , aff-bus =
   { dependencies = [ "avar", "prelude" ]
   , repo = "https://github.com/slamdata/purescript-aff-bus.git"
+  {- merge kl0tli's roles-declarations into master -}
   , version = "v4.0.0"
   }
 , avar =
@@ -121,6 +122,7 @@
     , "web-uievents"
     ]
   , repo = "https://github.com/slamdata/purescript-halogen.git"
+  {- TODO: make this repo compatible again; too many changes since original attempt -}
   , version = "v5.0.1"
   }
 , halogen-bootstrap =
@@ -163,6 +165,7 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/slamdata/purescript-pathy.git"
+  {- TODO: merge ps-0.14 branch into master -}
   , version = "v7.0.1"
   }
 , routing =

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -18,6 +18,7 @@
     , "web-html"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
+  {- TODO: Make library compatible again; too many changes since original attempt -}
   , version = "v6.1.1"
   }
 , uuid =

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -7,11 +7,13 @@
     , "profunctor-lenses"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-formless.git"
+  {- TODO: make library compatible again; too many changes since first attempt -}
   , version = "v1.0.0-rc.2"
   }
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
+  {- TODO: check to see whether library needs to be updated. created after first attempt -}
   , version = "v0.4.2"
   }
 , slug =


### PR DESCRIPTION
This merge was done by checking each repo's Network page on GitHub to determine which version of the project should be used.
- If the project had a branch that could be merged into `master`, it was stated there. 
- If it didn't, but had a fork with a branch that could be merged into master, this was stated. 

All other projects compiled on ps-0.14 in my original attempt back in February or so. I will need to check each repo again after this commit.