### PR TITLE
Re-add `purescript-option`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2632,6 +2632,29 @@
     "repo": "https://github.com/sharkdp/purescript-numbers.git",
     "version": "v7.0.0"
   },
+  "option": {
+    "dependencies": [
+      "argonaut-codecs",
+      "argonaut-core",
+      "codec",
+      "codec-argonaut",
+      "either",
+      "foreign",
+      "foreign-object",
+      "lists",
+      "maybe",
+      "prelude",
+      "profunctor",
+      "record",
+      "simple-json",
+      "transformers",
+      "tuples",
+      "type-equality",
+      "unsafe-coerce"
+    ],
+    "repo": "https://github.com/joneshf/purescript-option.git",
+    "version": "v6.0.0"
+  },
   "options": {
     "dependencies": [
       "contravariant",

--- a/src/groups/joneshf.dhall
+++ b/src/groups/joneshf.dhall
@@ -1,0 +1,24 @@
+{ option =
+  { dependencies =
+    [ "argonaut-codecs"
+    , "argonaut-core"
+    , "codec"
+    , "codec-argonaut"
+    , "either"
+    , "foreign"
+    , "foreign-object"
+    , "lists"
+    , "maybe"
+    , "profunctor"
+    , "prelude"
+    , "record"
+    , "simple-json"
+    , "transformers"
+    , "tuples"
+    , "type-equality"
+    , "unsafe-coerce"
+    ]
+  , repo = "https://github.com/joneshf/purescript-option.git"
+  , version = "v6.0.0"
+  }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -5,6 +5,7 @@ let packages =
       ⫽ ./groups/purescript-node.dhall
       ⫽ ./groups/ad-si.dhall
       ⫽ ./groups/awakesecurity.dhall
+      ⫽ ./groups/joneshf.dhall
       ⫽ ./groups/liamgoodacre.dhall
       ⫽ ./groups/lukajcb.dhall
       ⫽ ./groups/michaelxavier.dhall


### PR DESCRIPTION
`purescript-option` was removed in https://github.com/purescript/package-sets/pull/651. We add it back now that it's up to date.