### PR TITLE
Update 18 outdated packages (exclude affjax)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -14,11 +14,12 @@
       "foreign",
       "nullable",
       "prelude",
+      "refs",
       "web-html",
       "web-uievents"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-ace.git",
-    "version": "v7.0.0"
+    "version": "v7.1.0"
   },
   "aff": {
     "dependencies": [
@@ -79,6 +80,7 @@
       "aff",
       "argonaut-core",
       "arraybuffer-types",
+      "effect",
       "foreign",
       "form-urlencoded",
       "http-methods",
@@ -215,7 +217,7 @@
       "unordered-collections"
     ],
     "repo": "https://github.com/athanclark/purescript-arraybuffer-class.git",
-    "version": "v0.2.5"
+    "version": "v0.2.6"
   },
   "arraybuffer-types": {
     "dependencies": [],
@@ -635,7 +637,7 @@
       "variant"
     ],
     "repo": "https://github.com/natefaubion/purescript-checked-exceptions.git",
-    "version": "v3.1.0"
+    "version": "v3.1.1"
   },
   "cheerio": {
     "dependencies": [
@@ -691,7 +693,7 @@
       "transformers"
     ],
     "repo": "https://github.com/garyb/purescript-codec.git",
-    "version": "v3.0.0"
+    "version": "v3.1.0"
   },
   "codec-argonaut": {
     "dependencies": [
@@ -874,7 +876,7 @@
       "prelude"
     ],
     "repo": "https://github.com/garyb/purescript-debug.git",
-    "version": "v4.0.0"
+    "version": "v4.0.1"
   },
   "decimals": {
     "dependencies": [
@@ -1578,6 +1580,7 @@
       "const",
       "coroutines",
       "dom-indexed",
+      "effect",
       "foreign",
       "fork",
       "free",
@@ -1591,10 +1594,11 @@
       "transformers",
       "unsafe-coerce",
       "unsafe-reference",
+      "web-file",
       "web-uievents"
     ],
     "repo": "https://github.com/slamdata/purescript-halogen.git",
-    "version": "v5.0.1"
+    "version": "v5.1.0"
   },
   "halogen-bootstrap": {
     "dependencies": [
@@ -1627,7 +1631,7 @@
       "variant"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-formless.git",
-    "version": "v1.0.0-rc.2"
+    "version": "v1.0.0"
   },
   "halogen-hooks": {
     "dependencies": [
@@ -1635,7 +1639,7 @@
       "indexed-monad"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-hooks.git",
-    "version": "v0.4.2"
+    "version": "v0.4.3"
   },
   "halogen-hooks-extra": {
     "dependencies": [
@@ -1671,7 +1675,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/JordanMartinez/purescript-halogen-svg-elems.git",
-    "version": "v2.0.1"
+    "version": "v2.0.2"
   },
   "halogen-vdom": {
     "dependencies": [
@@ -1699,7 +1703,7 @@
       "unicode"
     ],
     "repo": "https://github.com/maxdeviant/purescript-heckin.git",
-    "version": "v1.0.3"
+    "version": "v1.1.0"
   },
   "heterogeneous": {
     "dependencies": [
@@ -1817,6 +1821,7 @@
       "http-methods",
       "indexed-monad",
       "media-types",
+      "node-buffer",
       "node-fs-aff",
       "node-http",
       "ordered-collections",
@@ -1829,7 +1834,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/purescript-hyper/hyper.git",
-    "version": "v0.11.0"
+    "version": "v0.11.1"
   },
   "hypertrout": {
     "dependencies": [
@@ -2625,7 +2630,7 @@
       "psci-support"
     ],
     "repo": "https://github.com/maxdeviant/purescript-npm-package-json.git",
-    "version": "v1.1.0"
+    "version": "v1.2.0"
   },
   "nullable": {
     "dependencies": [
@@ -2665,7 +2670,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/joneshf/purescript-option.git",
-    "version": "v6.0.0"
+    "version": "v6.0.1"
   },
   "options": {
     "dependencies": [
@@ -2802,7 +2807,7 @@
       "unicode"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-parsing.git",
-    "version": "v5.0.3"
+    "version": "v5.1.0"
   },
   "parsing-dataview": {
     "dependencies": [
@@ -2929,7 +2934,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/hoodunit/purescript-payload",
-    "version": "v0.3.0"
+    "version": "v0.3.1"
   },
   "phoenix": {
     "dependencies": [
@@ -3435,7 +3440,7 @@
       "web-html"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v6.1.1"
+    "version": "v6.2.0"
   },
   "react-basic-native": {
     "dependencies": [
@@ -4134,7 +4139,7 @@
       "unicode"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-strings-extra.git",
-    "version": "v2.1.0"
+    "version": "v2.2.1"
   },
   "stringutils": {
     "dependencies": [
@@ -4586,9 +4591,12 @@
     "version": "v4.0.0"
   },
   "unsafe-reference": {
-    "dependencies": [],
+    "dependencies": [
+      "effect",
+      "exceptions"
+    ],
     "repo": "https://github.com/purescript-contrib/purescript-unsafe-reference.git",
-    "version": "v3.0.1"
+    "version": "v3.1.0"
   },
   "untagged-union": {
     "dependencies": [

--- a/src/groups/athanclark.dhall
+++ b/src/groups/athanclark.dhall
@@ -14,7 +14,7 @@
     , "unordered-collections"
     ]
   , repo = "https://github.com/athanclark/purescript-arraybuffer-class.git"
-  , version = "v0.2.5"
+  , version = "v0.2.6"
   }
 , bip39 =
   { dependencies = [ "arraybuffer-types", "nullable" ]

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -1,7 +1,7 @@
 { codec =
   { dependencies = [ "transformers", "profunctor" ]
   , repo = "https://github.com/garyb/purescript-codec.git"
-  , version = "v3.0.0"
+  , version = "v3.1.0"
   }
 , codec-argonaut =
   { dependencies =
@@ -18,7 +18,7 @@
 , debug =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/garyb/purescript-debug.git"
-  , version = "v4.0.0"
+  , version = "v4.0.1"
   }
 , indexed-monad =
   { dependencies = [ "control", "newtype" ]

--- a/src/groups/hoodunit.dhall
+++ b/src/groups/hoodunit.dhall
@@ -18,6 +18,6 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/hoodunit/purescript-payload"
-  , version = "v0.3.0"
+  , version = "v0.3.1"
   }
 }

--- a/src/groups/joneshf.dhall
+++ b/src/groups/joneshf.dhall
@@ -19,6 +19,6 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/joneshf/purescript-option.git"
-  , version = "v6.0.0"
+  , version = "v6.0.1"
   }
 }

--- a/src/groups/jordanmartinez.dhall
+++ b/src/groups/jordanmartinez.dhall
@@ -6,7 +6,7 @@
 , halogen-svg-elems =
   { dependencies = [ "effect", "halogen", "prelude", "strings", "web-uievents" ]
   , repo = "https://github.com/JordanMartinez/purescript-halogen-svg-elems.git"
-  , version = "v2.0.1"
+  , version = "v2.0.2"
   }
 , halogen-hooks-extra =
   { dependencies = [ "halogen-hooks" ]

--- a/src/groups/maxdeviant.dhall
+++ b/src/groups/maxdeviant.dhall
@@ -8,12 +8,12 @@
     , "unicode"
     ]
   , repo = "https://github.com/maxdeviant/purescript-heckin.git"
-  , version = "v1.0.3"
+  , version = "v1.1.0"
   }
 , npm-package-json =
   { dependencies = [ "argonaut", "console", "effect", "psci-support" ]
   , repo = "https://github.com/maxdeviant/purescript-npm-package-json.git"
-  , version = "v1.1.0"
+  , version = "v1.2.0"
   }
 , which =
   { dependencies = [ "arrays", "console", "effect", "nullable", "psci-support" ]

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -6,7 +6,7 @@
 , checked-exceptions =
   { dependencies = [ "prelude", "transformers", "variant" ]
   , repo = "https://github.com/natefaubion/purescript-checked-exceptions.git"
-  , version = "v3.1.0"
+  , version = "v3.1.1"
   }
 , heterogeneous =
   { dependencies =

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -164,7 +164,7 @@
     , "unicode"
     ]
   , repo = "https://github.com/purescript-contrib/purescript-parsing.git"
-  , version = "v5.0.3"
+  , version = "v5.1.0"
   }
 , profunctor-lenses =
   { dependencies =
@@ -223,7 +223,7 @@
     , "unicode"
     ]
   , repo = "https://github.com/purescript-contrib/purescript-strings-extra.git"
-  , version = "v2.1.0"
+  , version = "v2.2.1"
   }
 , these =
   { dependencies = [ "gen", "tuples" ]
@@ -236,9 +236,9 @@
   , version = "v4.0.1"
   }
 , unsafe-reference =
-  { dependencies = [] : List Text
+  { dependencies = [ "effect", "exceptions" ]
   , repo =
       "https://github.com/purescript-contrib/purescript-unsafe-reference.git"
-  , version = "v3.0.1"
+  , version = "v3.1.0"
   }
 }

--- a/src/groups/purescript-hyper.dhall
+++ b/src/groups/purescript-hyper.dhall
@@ -12,6 +12,7 @@
     , "http-methods"
     , "indexed-monad"
     , "media-types"
+    , "node-buffer"
     , "node-fs-aff"
     , "node-http"
     , "ordered-collections"
@@ -24,7 +25,7 @@
     , "typelevel-prelude"
     ]
   , repo = "https://github.com/purescript-hyper/hyper.git"
-  , version = "v0.11.0"
+  , version = "v0.11.1"
   }
 , hypertrout =
   { dependencies =

--- a/src/groups/slamdata.dhall
+++ b/src/groups/slamdata.dhall
@@ -1,15 +1,16 @@
 { ace =
   { dependencies =
-    [ "effect"
-    , "web-html"
-    , "web-uievents"
-    , "arrays"
+    [ "arrays"
+    , "effect"
     , "foreign"
     , "nullable"
     , "prelude"
+    , "refs"
+    , "web-html"
+    , "web-uievents"
     ]
   , repo = "https://github.com/purescript-contrib/purescript-ace.git"
-  , version = "v7.0.0"
+  , version = "v7.1.0"
   }
 , aff =
   { dependencies =
@@ -40,6 +41,7 @@
     [ "aff"
     , "argonaut-core"
     , "arraybuffer-types"
+    , "effect"
     , "foreign"
     , "form-urlencoded"
     , "http-methods"
@@ -105,6 +107,7 @@
     , "const"
     , "coroutines"
     , "dom-indexed"
+    , "effect"
     , "foreign"
     , "fork"
     , "free"
@@ -118,10 +121,11 @@
     , "transformers"
     , "unsafe-coerce"
     , "unsafe-reference"
+    , "web-file"
     , "web-uievents"
     ]
   , repo = "https://github.com/slamdata/purescript-halogen.git"
-  , version = "v5.0.1"
+  , version = "v5.1.0"
   }
 , halogen-bootstrap =
   { dependencies = [ "halogen" ]

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -18,7 +18,7 @@
     , "web-html"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v6.1.1"
+  , version = "v6.2.0"
   }
 , uuid =
   { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -7,12 +7,12 @@
     , "profunctor-lenses"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-formless.git"
-  , version = "v1.0.0-rc.2"
+  , version = "v1.0.0"
   }
 , halogen-hooks =
   { dependencies = [ "halogen", "indexed-monad" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
-  , version = "v0.4.2"
+  , version = "v0.4.3"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
Followup to https://github.com/purescript/package-sets/pull/724#issuecomment-706773453

- ace (purescript-contrib/purescript-ace) ✖ v7.0.0 -> v7.1.0
- arraybuffer-class (athanclark/purescript-arraybuffer-class) ✖ v0.2.5 -> v0.2.6
- checked-exceptions (natefaubion/purescript-checked-exceptions) ✖ v3.1.0 -> v3.1.1
- codec (garyb/purescript-codec) ✖ v3.0.0 -> v3.1.0
- debug (garyb/purescript-debug) ✖ v4.0.0 -> v4.0.1
- halogen (slamdata/purescript-halogen) ✖ v5.0.1 -> v5.1.0
- halogen-formless (thomashoneyman/purescript-halogen-formless) ✖ v1.0.0-rc.2 -> v1.0.0
- halogen-hooks (thomashoneyman/purescript-halogen-hooks) ✖ v0.4.2 -> v0.4.3
- halogen-svg-elems (JordanMartinez/purescript-halogen-svg-elems) ✖ v2.0.1 -> v2.0.2
- heckin (maxdeviant/purescript-heckin) ✖ v1.0.3 -> v1.1.0
- hyper (purescript-hyper/hyper) ✖ v0.11.0 -> v0.11.1
- npm-package-json (maxdeviant/purescript-npm-package-json) ✖ v1.1.0 -> v1.2.0
- option (joneshf/purescript-option) ✖ v6.0.0 -> v6.0.1
- parsing (purescript-contrib/purescript-parsing) ✖ v5.0.3 -> v5.1.0
- payload (hoodunit/purescript-payload) ✖ v0.3.0 -> v0.3.1
- react-basic-hooks (spicydonuts/purescript-react-basic-hooks) ✖ v6.1.1 -> v6.2.0
- strings-extra (purescript-contrib/purescript-strings-extra) ✖ v2.1.0 -> v2.2.1
- unsafe-reference (purescript-contrib/purescript-unsafe-reference) ✖ v3.0.1 -> v3.1.0

affjax is not updated, see <https://github.com/purescript/package-sets/pull/724#issuecomment-706773453>

Solves #723
