### PR TITLE
Updates nix-install action to v12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v9
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-20.09
     - uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v9
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
       - name: Render packages.dhall
         run: |
           nix-shell --run '>packages.dhall dhall <<< ./src/packages.dhall'


### PR DESCRIPTION
This avoids the newest Github Action deprecations. Starting from version 11 it is necessary to specify the `nix_path`, so this PR also does that.