### PR TITLE
Add profunctor to parallel dependencies

### DIFF
--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -370,6 +370,7 @@
     , "maybe"
     , "newtype"
     , "prelude"
+    , "profunctor"
     , "refs"
     , "transformers"
     ]


### PR DESCRIPTION
The dependency was added in https://github.com/purescript/purescript-parallel/pull/28.