### PR TITLE
Automatically generate packages.json file on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: build
 
 on:
   pull_request:
+    branches: master
   push:
+    branches: master
 
 jobs:
   build:
@@ -21,13 +23,6 @@ jobs:
 
       - name: Generate packages.json file from the package set
         run: |
-          # Set Git configuration to the GitHub Action user, which won't trigger
-          # subsequent runs of this Action.
-          git config --local pull.ff only
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git pull
-
           # Generate the new packages.json file
           nix-shell --run 'make generate'
 
@@ -35,24 +30,18 @@ jobs:
           nix-shell --run 'make verify-registry'
           nix-shell --run 'make test-psc-package'
 
-          # Only commit if the prior commands dirtied the working tree
-          git diff --quiet || git commit -a -m "Update packages.json."
+      - name: Check for and commit modified files
+          id: git-check
+          run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
 
-      - name: Push changes if necessary
-        uses: ad-m/github-push-action@master
-        with:
-          branch: ${{ github.ref }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  tests:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: cachix/install-nix-action@v12
-        with:
-          nix_path: nixpkgs=channel:nixos-20.09
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'actions@github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Update packages.json file"
+          git push
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,18 +3,61 @@ name: build
 on:
   pull_request:
   push:
+
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Otherwise the token used is the GITHUB_TOKEN instead of personal
+          persist-credentials: false
+          # Otherwise will fail to push refs to destination repo
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
+
+      - name: Update tooling versions
+        run: |
+          # Set Git configuration to the GitHub Action user, which won't trigger
+          # subsequent runs of this Action.
+          git config --local pull.ff only
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git pull
+
+          # Generate the new packages.json file
+          nix-shell --run 'make generate'
+
+          # Run verification steps
+          nix-shell --run 'make verify-registry'
+          nix-shell --run 'make test-psc-package'
+
+          # Only commit if the prior commands dirtied the working tree
+          git diff --quiet || git commit -a -m "Update packages.json."
+
+      - name: Push changes if necessary
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{ github.ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v12
-      with:
-        nix_path: nixpkgs=channel:nixos-20.09
-    - uses: actions/cache@v2
-      with:
-        path: |
-          output
-          .psc-package
-        key: ${{ runner.os }}-build-products
-    - run: nix-shell --run 'make ci'
+      - uses: actions/checkout@v2
+
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            output
+            .psc-package
+          key: ${{ runner.os }}-build-products
+
+      - run: nix-shell --run 'cd src && spago verify-set'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-20.09
 
-      - name: Update tooling versions
+      - name: Generate packages.json file from the package set
         run: |
           # Set Git configuration to the GitHub Action user, which won't trigger
           # subsequent runs of this Action.
@@ -45,6 +45,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   tests:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,7 @@ name: build
 
 on:
   pull_request:
-    branches: master
   push:
-    branches: master
 
 jobs:
   build:

--- a/packages.json
+++ b/packages.json
@@ -938,8 +938,8 @@
       "prelude",
       "strings"
     ],
-    "repo": "https://github.com/natefaubion/purescript-dodo-printer/",
-    "version": "v1.0.8"
+    "repo": "https://github.com/natefaubion/purescript-dodo-printer.git",
+    "version": "v1.0.9"
   },
   "dom-filereader": {
     "dependencies": [

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -119,7 +119,7 @@
 , dodo-printer =
   { dependencies =
     [ "ansi", "foldable-traversable", "lists", "maybe", "prelude", "strings" ]
-  , repo = "https://github.com/natefaubion/purescript-dodo-printer/"
-  , version = "v1.0.8"
+  , repo = "https://github.com/natefaubion/purescript-dodo-printer.git"
+  , version = "v1.0.9"
   }
 }


### PR DESCRIPTION
This PR modifies the GitHub Actions pipeline to update and commit (if necessary) the `packages.json` file.

With this change, contributors only need to update the relevant `.dhall` files (which can often be done strictly through the GitHub UI, minimizing the effort required). If the update changes the packages.json file then it will automatically be committed to their branch. If it does not, then nothing will be committed. Either way the tests will still run -- they don't rely on the packages.json file in any case.

You can see an example of this action working in this commit, performed by the GitHub Actions user: https://github.com/purescript/package-sets/commit/77303d42c6ace57e2d5f04fc9d9856856232ef87

I _believe_ this should work on any pull request to the repository, but I can't test that until this is merged and a PR from an account without access to this repository makes a pull request. So I propose:

1. If this generally looks good then we merge it
2. Another member of the Contributors org who doesn't have access to this repository updates a package
3. We verify that this CI does properly commit to their branch
4. If it does not, then I revert this commit to go back to the previous CI process.

@f-f I'm not sure what README updates to make to help casual contributors know that they just have to update the relevant `.dhall` file for their changes. Do you have any suggestions?