### PR TITLE
Add collegevine/elmish

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1035,6 +1035,25 @@
     "repo": "https://github.com/purescript/purescript-either.git",
     "version": "v4.1.1"
   },
+  "elmish": {
+    "dependencies": [
+      "aff",
+      "argonaut-core",
+      "console",
+      "debug",
+      "either",
+      "foreign-object",
+      "functions",
+      "maybe",
+      "prelude",
+      "record",
+      "tuples",
+      "typelevel-prelude",
+      "web-html"
+    ],
+    "repo": "https://github.com/collegevine/purescript-elmish.git",
+    "version": "v0.3.0"
+  },
   "email-validate": {
     "dependencies": [
       "aff",

--- a/src/groups/collegevine.dhall
+++ b/src/groups/collegevine.dhall
@@ -1,0 +1,22 @@
+{ elmish =
+    { dependencies =
+        [ "aff"
+        , "argonaut-core"
+        , "console"
+        , "debug"
+        , "either"
+        , "foreign-object"
+        , "functions"
+        , "maybe"
+        , "prelude"
+        , "record"
+        , "tuples"
+        , "typelevel-prelude"
+        , "web-html"
+        ]
+    , repo =
+        "https://github.com/collegevine/purescript-elmish.git"
+    , version =
+        "v0.3.0"
+    }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -109,5 +109,6 @@ let packages =
       ⫽ ./groups/chekoopa.dhall
       ⫽ ./groups/newlandsvalley.dhall
       ⫽ ./groups/ajnsit.dhall
+      ⫽ ./groups/collegevine.dhall
 
 in  packages


### PR DESCRIPTION
1. I hope I did good. I tried to follow the various instructions and guidelines, but this transitional state is mighty confusing :-/
2. There is no corresponding PR to `new-packages.json` in the registry repo, because this package is already in `bower-packages.json`. It is my understanding that the two shouldn't overlap.
3. There will also be `elmish-html`, but it will have to be in a separate PR, because it depends on `elmish`, so I can't give it a proper `spago.dhall` file until `elmish` is in the set. Unless I'm missing something?