### PR TITLE
Newtype and generics rep

### DIFF
--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -64,7 +64,6 @@
     , "arrays"
     , "effect"
     , "foreign-object"
-    , "generics-rep"
     , "identity"
     , "integers"
     , "maybe"
@@ -96,7 +95,7 @@
   }
 , argonaut-generic =
   { dependencies =
-    [ "argonaut-codecs", "argonaut-core", "generics-rep", "record" ]
+    [ "argonaut-codecs", "argonaut-core", "record" ]
   , repo =
       "https://github.com/purescript-contrib/purescript-argonaut-generic.git"
   , version = "main"
@@ -134,7 +133,6 @@
   { dependencies =
     [ "colors"
     , "console"
-    , "generics-rep"
     , "nonempty"
     , "profunctor"
     , "strings"
@@ -153,7 +151,6 @@
   { dependencies =
     [ "datetime"
     , "fixed-points"
-    , "generics-rep"
     , "lists"
     , "parsing"
     , "prelude"
@@ -294,7 +291,6 @@
     , "effect"
     , "exceptions"
     , "gen"
-    , "generics-rep"
     , "numbers"
     , "integers"
     , "lists"
@@ -401,7 +397,6 @@
 , uri =
   { dependencies =
     [ "arrays"
-    , "generics-rep"
     , "numbers"
     , "integers"
     , "js-uri"

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -231,12 +231,6 @@
   , repo = "https://github.com/purescript/purescript-gen.git"
   , version = "master"
   }
-, generics-rep =
-  { dependencies =
-    [ "enums", "foldable-traversable", "maybe", "newtype", "prelude" ]
-  , repo = "https://github.com/purescript/purescript-generics-rep.git"
-  , version = "master"
-  }
 , graphs =
   { dependencies = [ "ordered-collections", "catenable-lists" ]
   , repo = "https://github.com/purescript/purescript-graphs.git"
@@ -418,7 +412,6 @@
     , "exceptions"
     , "foldable-traversable"
     , "gen"
-    , "generics-rep"
     , "identity"
     , "integers"
     , "lazy"

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -312,7 +312,7 @@
   , version = "master"
   }
 , newtype =
-  { dependencies = [ "prelude" ]
+  { dependencies = [ "prelude", "safe-coerce" ]
   , repo = "https://github.com/purescript/purescript-newtype.git"
   , version = "master"
   }


### PR DESCRIPTION
Updates `prepare-0.14` to account for the newtype PR where Coercible was made a superclass of Newtype and generics-rep port to Prelude.

I'm using this mainly to see what packages got broken as a result of these changes.