### PR TITLE
Add safe-coerce to packages.json and as dependency of newtype

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2337,7 +2337,8 @@
   },
   "newtype": {
     "dependencies": [
-      "prelude"
+      "prelude",
+      "safe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-newtype.git",
     "version": "v3.0.0"
@@ -3616,6 +3617,13 @@
     ],
     "repo": "https://github.com/natefaubion/purescript-run-streaming.git",
     "version": "v2.0.0"
+  },
+  "safe-coerce": {
+    "dependencies": [
+      "unsafe-coerce"
+    ],
+    "repo": "https://github.com/purescript/purescript-safe-coerce.git",
+    "version": "master"
   },
   "safely": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -117,7 +117,6 @@
       "arrays",
       "effect",
       "foreign-object",
-      "generics-rep",
       "identity",
       "integers",
       "maybe",
@@ -149,7 +148,6 @@
     "dependencies": [
       "argonaut-codecs",
       "argonaut-core",
-      "generics-rep",
       "record"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-argonaut-generic.git",
@@ -169,7 +167,6 @@
       "arrays",
       "control",
       "foldable-traversable",
-      "generics-rep",
       "maybe",
       "nonempty",
       "prelude",
@@ -414,7 +411,6 @@
       "either",
       "foldable-traversable",
       "foreign-object",
-      "generics-rep",
       "maybe",
       "newtype",
       "prelude",
@@ -530,7 +526,6 @@
   },
   "byte-codec": {
     "dependencies": [
-      "generics-rep",
       "integers",
       "sized-vectors"
     ],
@@ -697,7 +692,6 @@
     "dependencies": [
       "argonaut-core",
       "codec",
-      "generics-rep",
       "ordered-collections",
       "type-equality",
       "variant"
@@ -807,7 +801,6 @@
     "dependencies": [
       "colors",
       "console",
-      "generics-rep",
       "nonempty",
       "profunctor",
       "strings",
@@ -828,7 +821,6 @@
     "dependencies": [
       "arrays",
       "foreign-object",
-      "generics-rep",
       "maybe",
       "ordered-collections",
       "prelude",
@@ -968,7 +960,6 @@
   "email-validate": {
     "dependencies": [
       "aff",
-      "generics-rep",
       "string-parsers",
       "transformers"
     ],
@@ -1132,7 +1123,6 @@
   },
   "float32": {
     "dependencies": [
-      "generics-rep",
       "prelude"
     ],
     "repo": "https://github.com/athanclark/purescript-float32.git",
@@ -1188,7 +1178,6 @@
       "exceptions",
       "foreign",
       "foreign-object",
-      "generics-rep",
       "identity",
       "ordered-collections",
       "proxy",
@@ -1249,7 +1238,6 @@
   },
   "format-nix": {
     "dependencies": [
-      "generics-rep",
       "motsunabe",
       "prelude"
     ],
@@ -1260,7 +1248,6 @@
     "dependencies": [
       "datetime",
       "fixed-points",
-      "generics-rep",
       "lists",
       "parsing",
       "prelude",
@@ -1396,7 +1383,6 @@
     "dependencies": [
       "foldable-traversable",
       "foreign-object",
-      "generics-rep",
       "newtype",
       "ordered-collections",
       "prelude",
@@ -1459,17 +1445,6 @@
     ],
     "repo": "https://github.com/purescript/purescript-gen.git",
     "version": "v2.1.1"
-  },
-  "generics-rep": {
-    "dependencies": [
-      "enums",
-      "foldable-traversable",
-      "maybe",
-      "newtype",
-      "prelude"
-    ],
-    "repo": "https://github.com/purescript/purescript-generics-rep.git",
-    "version": "v6.1.1"
   },
   "geometry-plane": {
     "dependencies": [
@@ -1608,7 +1583,6 @@
   },
   "halogen-formless": {
     "dependencies": [
-      "generics-rep",
       "halogen",
       "heterogeneous",
       "profunctor-lenses",
@@ -1695,7 +1669,6 @@
       "const",
       "effect",
       "errors",
-      "generics-rep",
       "lists",
       "ordered-collections",
       "orders",
@@ -1706,7 +1679,6 @@
   },
   "html-parser-halogen": {
     "dependencies": [
-      "generics-rep",
       "halogen",
       "prelude",
       "string-parsers"
@@ -1767,7 +1739,6 @@
       "biscotti-session",
       "effect",
       "either",
-      "generics-rep",
       "httpure",
       "maybe",
       "profunctor-lenses",
@@ -1789,7 +1760,6 @@
       "control",
       "effect",
       "foldable-traversable",
-      "generics-rep",
       "http-methods",
       "indexed-monad",
       "media-types",
@@ -1934,7 +1904,6 @@
       "console",
       "effect",
       "foreign",
-      "generics-rep",
       "prelude",
       "psci-support",
       "spec-quickcheck",
@@ -1945,7 +1914,6 @@
   },
   "json-schema": {
     "dependencies": [
-      "generics-rep",
       "prelude",
       "simple-json"
     ],
@@ -1979,7 +1947,6 @@
   },
   "kishimen": {
     "dependencies": [
-      "generics-rep",
       "prelude",
       "typelevel-prelude",
       "variant"
@@ -2021,7 +1988,6 @@
   "lenient-html-parser": {
     "dependencies": [
       "console",
-      "generics-rep",
       "prelude",
       "string-parsers"
     ],
@@ -2076,7 +2042,6 @@
   },
   "logging-journald": {
     "dependencies": [
-      "generics-rep",
       "logging",
       "systemd-journald"
     ],
@@ -2167,7 +2132,6 @@
   "memoize": {
     "dependencies": [
       "either",
-      "generics-rep",
       "integers",
       "lazy",
       "lists",
@@ -2884,7 +2848,6 @@
     "dependencies": [
       "foreign",
       "foreign-object",
-      "generics-rep",
       "invariant",
       "newtype",
       "ordered-collections",
@@ -3038,7 +3001,6 @@
   "proxying": {
     "dependencies": [
       "effect",
-      "generics-rep",
       "prelude",
       "typelevel-prelude"
     ],
@@ -3144,7 +3106,6 @@
       "exceptions",
       "foldable-traversable",
       "gen",
-      "generics-rep",
       "identity",
       "integers",
       "lazy",
@@ -3484,7 +3445,6 @@
     "dependencies": [
       "argonaut",
       "effect",
-      "generics-rep",
       "prelude",
       "quickcheck",
       "typelevel"
@@ -3504,7 +3464,6 @@
     "dependencies": [
       "bifunctors",
       "either",
-      "generics-rep",
       "profunctor-lenses"
     ],
     "repo": "https://github.com/krisajenkins/purescript-remotedata.git",
@@ -3552,7 +3511,6 @@
       "arrays",
       "control",
       "either",
-      "generics-rep",
       "globals",
       "lazy",
       "prelude",
@@ -3667,7 +3625,6 @@
     "dependencies": [
       "effect",
       "either",
-      "generics-rep",
       "prelude",
       "psci-support",
       "validation"
@@ -3689,7 +3646,6 @@
     "dependencies": [
       "effect",
       "functions",
-      "generics-rep",
       "maybe",
       "prelude",
       "web-events"
@@ -3776,7 +3732,6 @@
   },
   "simple-json-generics": {
     "dependencies": [
-      "generics-rep",
       "simple-json"
     ],
     "repo": "https://github.com/justinwoo/purescript-simple-json-generics.git",
@@ -3859,7 +3814,6 @@
   "slug": {
     "dependencies": [
       "argonaut-codecs",
-      "generics-rep",
       "maybe",
       "prelude",
       "strings",
@@ -3935,7 +3889,6 @@
       "exceptions",
       "foldable-traversable",
       "fork",
-      "generics-rep",
       "now",
       "pipes",
       "prelude",
@@ -4085,7 +4038,6 @@
       "cssom",
       "effect",
       "foreign",
-      "generics-rep",
       "ordered-collections",
       "prelude",
       "refs",
@@ -4140,7 +4092,6 @@
   },
   "svg-parser": {
     "dependencies": [
-      "generics-rep",
       "prelude",
       "string-parsers"
     ],
@@ -4346,7 +4297,6 @@
   },
   "tuples-native": {
     "dependencies": [
-      "generics-rep",
       "typelevel",
       "unsafe-coerce"
     ],
@@ -4368,7 +4318,6 @@
   "typedenv": {
     "dependencies": [
       "foreign-object",
-      "generics-rep",
       "integers",
       "numbers",
       "record",
@@ -4420,7 +4369,6 @@
   },
   "uint": {
     "dependencies": [
-      "generics-rep",
       "math",
       "maybe",
       "quickcheck"
@@ -4528,7 +4476,6 @@
   "uri": {
     "dependencies": [
       "arrays",
-      "generics-rep",
       "globals",
       "integers",
       "parsing",

--- a/src/groups/anttih.dhall
+++ b/src/groups/anttih.dhall
@@ -5,8 +5,7 @@
   }
 , selective =
   { dependencies =
-    [ "generics-rep"
-    , "validation"
+    [ "validation"
     , "psci-support"
     , "effect"
     , "either"

--- a/src/groups/athanclark.dhall
+++ b/src/groups/athanclark.dhall
@@ -22,12 +22,12 @@
   , version = "v1.0.1"
   }
 , byte-codec =
-  { dependencies = [ "generics-rep", "integers", "sized-vectors" ]
+  { dependencies = [ "integers", "sized-vectors" ]
   , repo = "https://github.com/athanclark/purescript-byte-codec.git"
   , version = "v0.0.1"
   }
 , float32 =
-  { dependencies = [ "generics-rep", "prelude" ]
+  { dependencies = [ "prelude" ]
   , repo = "https://github.com/athanclark/purescript-float32.git"
   , version = "v0.2.0"
   }
@@ -108,7 +108,7 @@
   , version = "v0.3.1"
   }
 , tuples-native =
-  { dependencies = [ "generics-rep", "typelevel", "unsafe-coerce" ]
+  { dependencies = [ "typelevel", "unsafe-coerce" ]
   , repo = "https://github.com/athanclark/purescript-tuples-native.git"
   , version = "v2.1.0"
   }

--- a/src/groups/cdepillabout.dhall
+++ b/src/groups/cdepillabout.dhall
@@ -1,5 +1,5 @@
 { email-validate =
-  { dependencies = [ "aff", "generics-rep", "string-parsers", "transformers" ]
+  { dependencies = [ "aff", "string-parsers", "transformers" ]
   , repo = "https://github.com/cdepillabout/purescript-email-validate.git"
   , version = "v5.0.0"
   }

--- a/src/groups/citizennet.dhall
+++ b/src/groups/citizennet.dhall
@@ -2,7 +2,6 @@
   { dependencies =
     [ "foldable-traversable"
     , "foreign-object"
-    , "generics-rep"
     , "newtype"
     , "ordered-collections"
     , "prelude"

--- a/src/groups/danieljharvey.dhall
+++ b/src/groups/danieljharvey.dhall
@@ -2,7 +2,6 @@
   { dependencies =
     [ "argonaut"
     , "effect"
-    , "generics-rep"
     , "prelude"
     , "quickcheck"
     , "typelevel"
@@ -29,7 +28,6 @@
   { dependencies =
     [ "effect"
     , "foreign"
-    , "generics-rep"
     , "ordered-collections"
     , "prelude"
     , "refs"

--- a/src/groups/drewolson.dhall
+++ b/src/groups/drewolson.dhall
@@ -46,7 +46,6 @@
     , "biscotti-session"
     , "effect"
     , "either"
-    , "generics-rep"
     , "httpure"
     , "maybe"
     , "profunctor-lenses"

--- a/src/groups/felixmulder.dhall
+++ b/src/groups/felixmulder.dhall
@@ -1,5 +1,5 @@
 { json-schema =
-    { dependencies = [ "generics-rep", "prelude", "simple-json" ]
+    { dependencies = [ "prelude", "simple-json" ]
     , repo = "https://github.com/felixmulder/purescript-json-schema.git"
     {- TODO: this version includes the commits I made that originally made
        this repo compatible with PS v0.14 before more changes were made.

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -7,7 +7,6 @@
   { dependencies =
     [ "argonaut-core"
     , "codec"
-    , "generics-rep"
     , "ordered-collections"
     , "type-equality"
     , "variant"

--- a/src/groups/i-am-tom.dhall
+++ b/src/groups/i-am-tom.dhall
@@ -2,7 +2,6 @@
   { dependencies =
     [ "arrays"
     , "foreign-object"
-    , "generics-rep"
     , "maybe"
     , "ordered-collections"
     , "prelude"

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -20,7 +20,7 @@
   , version = "v2.0.0"
   }
 , format-nix =
-  { dependencies = [ "generics-rep", "motsunabe", "prelude" ]
+  { dependencies = [ "motsunabe", "prelude" ]
   , repo = "https://github.com/justinwoo/format-nix.git"
   , version = "v0.3.0"
   }
@@ -44,13 +44,13 @@
   , version = "v2.0.0"
   }
 , kishimen =
-  { dependencies = [ "generics-rep", "prelude", "typelevel-prelude", "variant" ]
+  { dependencies = [ "prelude", "typelevel-prelude", "variant" ]
   , repo = "https://github.com/justinwoo/purescript-kishimen.git"
   , version = "v1.0.1"
   }
 -}
 , lenient-html-parser =
-  { dependencies = [ "console", "generics-rep", "prelude", "string-parsers" ]
+  { dependencies = [ "console", "prelude", "string-parsers" ]
   , repo = "https://github.com/justinwoo/purescript-lenient-html-parser.git"
   , version = "v4.0.0"
   }
@@ -149,7 +149,7 @@
   , version = "master"
   }
 , simple-json-generics =
-  { dependencies = [ "generics-rep", "simple-json" ]
+  { dependencies = [ "simple-json" ]
   , repo = "https://github.com/justinwoo/purescript-simple-json-generics.git"
   , version = "v0.1.0"
   }

--- a/src/groups/klntsky.dhall
+++ b/src/groups/klntsky.dhall
@@ -3,7 +3,6 @@
     [ "arrays"
     , "control"
     , "foldable-traversable"
-    , "generics-rep"
     , "maybe"
     , "nonempty"
     , "prelude"
@@ -29,7 +28,6 @@
 , bower-json =
   { dependencies =
     [ "prelude"
-    , "generics-rep"
     , "maybe"
     , "arrays"
     , "either"

--- a/src/groups/krisajenkins.dhall
+++ b/src/groups/krisajenkins.dhall
@@ -1,6 +1,6 @@
 { remotedata =
   { dependencies =
-    [ "bifunctors", "either", "generics-rep", "profunctor-lenses" ]
+    [ "bifunctors", "either", "profunctor-lenses" ]
   , repo = "https://github.com/krisajenkins/purescript-remotedata.git"
   , version = "v4.2.0"
   }

--- a/src/groups/matthew-hilty.dhall
+++ b/src/groups/matthew-hilty.dhall
@@ -4,7 +4,6 @@
     , "const"
     , "effect"
     , "errors"
-    , "generics-rep"
     , "lists"
     , "ordered-collections"
     , "orders"
@@ -14,7 +13,7 @@
   , version = "v0.2.0"
   }
 , proxying =
-  { dependencies = [ "effect", "generics-rep", "prelude", "typelevel-prelude" ]
+  { dependencies = [ "effect", "prelude", "typelevel-prelude" ]
   , repo = "https://github.com/matthew-hilty/purescript-proxying.git"
   {- TODO: my fork's polykindsupdate can be merged into master -}
   , version = "v1.1.0"

--- a/src/groups/michaelxavier.dhall
+++ b/src/groups/michaelxavier.dhall
@@ -1,6 +1,6 @@
 { server-sent-events =
   { dependencies =
-    [ "effect", "functions", "generics-rep", "maybe", "prelude", "web-events" ]
+    [ "effect", "functions", "maybe", "prelude", "web-events" ]
   , repo = "https://github.com/MichaelXavier/purescript-server-sent-events.git"
   , version = "v0.2.0"
   }

--- a/src/groups/natefaubion.dhall
+++ b/src/groups/natefaubion.dhall
@@ -42,7 +42,6 @@
     [ "arrays"
     , "control"
     , "either"
-    , "generics-rep"
     , "numbers"
     , "lazy"
     , "prelude"

--- a/src/groups/nsaunders.dhall
+++ b/src/groups/nsaunders.dhall
@@ -22,7 +22,6 @@
 , typedenv =
   { dependencies =
     [ "foreign-object"
-    , "generics-rep"
     , "integers"
     , "numbers"
     , "record"

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -44,7 +44,6 @@
     , "exceptions"
     , "foreign"
     , "foreign-object"
-    , "generics-rep"
     , "identity"
     , "ordered-collections"
     , "record"
@@ -60,7 +59,6 @@
 , memoize =
   { dependencies =
     [ "either"
-    , "generics-rep"
     , "integers"
     , "lazy"
     , "lists"

--- a/src/groups/paluh.dhall
+++ b/src/groups/paluh.dhall
@@ -1,5 +1,5 @@
 { logging-journald =
-  { dependencies = [ "generics-rep", "logging", "systemd-journald" ]
+  { dependencies = [ "logging", "systemd-journald" ]
   , repo = "https://github.com/paluh/purescript-logging-journald.git"
   , version = "v0.3.2"
   }
@@ -12,7 +12,6 @@
   { dependencies =
     [ "foreign"
     , "foreign-object"
-    , "generics-rep"
     , "invariant"
     , "newtype"
     , "ordered-collections"

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -64,8 +64,6 @@
     , "arrays"
     , "effect"
     , "foreign-object"
-    , "generics-rep"
-    , "identity"
     , "integers"
     , "maybe"
     , "nonempty"
@@ -96,7 +94,7 @@
   }
 , argonaut-generic =
   { dependencies =
-    [ "argonaut-codecs", "argonaut-core", "generics-rep", "record" ]
+    [ "argonaut-codecs", "argonaut-core", "record" ]
   , repo =
       "https://github.com/purescript-contrib/purescript-argonaut-generic.git"
   , version = "main"
@@ -134,7 +132,6 @@
   { dependencies =
     [ "colors"
     , "console"
-    , "generics-rep"
     , "nonempty"
     , "profunctor"
     , "strings"
@@ -153,7 +150,6 @@
   { dependencies =
     [ "datetime"
     , "fixed-points"
-    , "generics-rep"
     , "lists"
     , "parsing"
     , "prelude"
@@ -294,7 +290,6 @@
     , "effect"
     , "exceptions"
     , "gen"
-    , "generics-rep"
     , "numbers"
     , "integers"
     , "lists"
@@ -401,7 +396,6 @@
 , uri =
   { dependencies =
     [ "arrays"
-    , "generics-rep"
     , "numbers"
     , "integers"
     , "js-uri"

--- a/src/groups/purescript-hyper.dhall
+++ b/src/groups/purescript-hyper.dhall
@@ -8,7 +8,6 @@
     , "control"
     , "effect"
     , "foldable-traversable"
-    , "generics-rep"
     , "http-methods"
     , "indexed-monad"
     , "media-types"

--- a/src/groups/purescript-spec.dhall
+++ b/src/groups/purescript-spec.dhall
@@ -7,7 +7,6 @@
     , "exceptions"
     , "foldable-traversable"
     , "fork"
-    , "generics-rep"
     , "now"
     , "pipes"
     , "prelude"

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -231,12 +231,6 @@
   , repo = "https://github.com/purescript/purescript-gen.git"
   , version = "master"
   }
-, generics-rep =
-  { dependencies =
-    [ "enums", "foldable-traversable", "maybe", "newtype", "prelude" ]
-  , repo = "https://github.com/purescript/purescript-generics-rep.git"
-  , version = "master"
-  }
 , graphs =
   { dependencies = [ "ordered-collections", "catenable-lists" ]
   , repo = "https://github.com/purescript/purescript-graphs.git"
@@ -418,7 +412,6 @@
     , "exceptions"
     , "foldable-traversable"
     , "gen"
-    , "generics-rep"
     , "identity"
     , "integers"
     , "lazy"

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -312,7 +312,7 @@
   , version = "master"
   }
 , newtype =
-  { dependencies = [ "prelude" ]
+  { dependencies = [ "prelude", "safe-coerce" ]
   , repo = "https://github.com/purescript/purescript-newtype.git"
   , version = "master"
   }

--- a/src/groups/reactormonk.dhall
+++ b/src/groups/reactormonk.dhall
@@ -32,7 +32,6 @@
     [ "console"
     , "effect"
     , "foreign"
-    , "generics-rep"
     , "prelude"
     , "psci-support"
     , "spec-quickcheck"

--- a/src/groups/rnons.dhall
+++ b/src/groups/rnons.dhall
@@ -4,12 +4,12 @@
   , version = "v1.0.0-rc.1"
   }
 , html-parser-halogen =
-  { dependencies = [ "generics-rep", "halogen", "prelude", "string-parsers" ]
+  { dependencies = [ "halogen", "prelude", "string-parsers" ]
   , repo = "https://github.com/rnons/purescript-html-parser-halogen.git"
   , version = "v1.0.0-rc.2"
   }
 , svg-parser =
-  { dependencies = [ "generics-rep", "prelude", "string-parsers" ]
+  { dependencies = [ "prelude", "string-parsers" ]
   , repo = "https://github.com/rnons/purescript-svg-parser.git"
   , version = "v1.0.0"
   }

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -3,7 +3,6 @@
     [ "halogen"
     , "variant"
     , "heterogeneous"
-    , "generics-rep"
     , "profunctor-lenses"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-formless.git"
@@ -22,7 +21,6 @@
     , "maybe"
     , "strings"
     , "unicode"
-    , "generics-rep"
     , "argonaut-codecs"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-slug.git"

--- a/src/groups/zaquest.dhall
+++ b/src/groups/zaquest.dhall
@@ -1,5 +1,5 @@
 { uint =
-  { dependencies = [ "generics-rep", "math", "maybe", "quickcheck" ]
+  { dependencies = [ "math", "maybe", "quickcheck" ]
   , repo = "https://github.com/zaquest/purescript-uint.git"
   , version = "v5.1.4"
   }

--- a/src/updatedLibs.dhall
+++ b/src/updatedLibs.dhall
@@ -54,7 +54,6 @@ in shared
     , "enums"
     , "semirings"
     , "strings"
-    , "generics-rep"
     , "foreign"
     , "free"
     , "quickcheck"


### PR DESCRIPTION
* `safe-coerce` is present in `src/groups/purescript.dhall`, but not in `packages.json`. 
* `newtype` depends on `safe-coerce`, but this wasn't reflected in `purescript.dhall`, nor in `packages.json`

I bumped into this when working on preparing my own project for 0.14.
I asked a question about this [on the forum](https://discourse.purescript.org/t/where-is-safe-coerce/1981) and @hdgarrood suggested that a PR would be useful. So here I am.