### PR TITLE
Spec discovery

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4232,8 +4232,8 @@
       "prelude",
       "spec"
     ],
-    "repo": "https://github.com/owickstrom/purescript-spec-discovery.git",
-    "version": "v4.0.0"
+    "repo": "https://github.com/purescript-spec/purescript-spec-discovery.git",
+    "version": "v5.0.0"
   },
   "spec-quickcheck": {
     "dependencies": [

--- a/src/groups/collegevine.dhall
+++ b/src/groups/collegevine.dhall
@@ -1,30 +1,25 @@
 { elmish =
-    { dependencies =
-        [ "aff"
-        , "argonaut-core"
-        , "console"
-        , "debug"
-        , "either"
-        , "foreign-object"
-        , "functions"
-        , "maybe"
-        , "prelude"
-        , "record"
-        , "tuples"
-        , "typelevel-prelude"
-        , "web-html"
-        ]
-    , repo =
-        "https://github.com/collegevine/purescript-elmish.git"
-    , version =
-        "v0.3.1"
-    }
+  { dependencies =
+    [ "aff"
+    , "argonaut-core"
+    , "console"
+    , "debug"
+    , "either"
+    , "foreign-object"
+    , "functions"
+    , "maybe"
+    , "prelude"
+    , "record"
+    , "tuples"
+    , "typelevel-prelude"
+    , "web-html"
+    ]
+  , repo = "https://github.com/collegevine/purescript-elmish.git"
+  , version = "v0.3.1"
+  }
 , elmish-html =
-    { dependencies =
-        [ "elmish", "foreign-object" ]
-    , repo =
-        "https://github.com/collegevine/purescript-elmish-html.git"
-    , version =
-        "v0.2.0"
-    }
+  { dependencies = [ "elmish", "foreign-object" ]
+  , repo = "https://github.com/collegevine/purescript-elmish-html.git"
+  , version = "v0.2.0"
+  }
 }

--- a/src/groups/owickstrom.dhall
+++ b/src/groups/owickstrom.dhall
@@ -1,9 +1,4 @@
-{ spec-discovery =
-  { dependencies = [ "arrays", "effect", "node-fs", "prelude", "spec" ]
-  , repo = "https://github.com/owickstrom/purescript-spec-discovery.git"
-  , version = "v4.0.0"
-  }
-, spec-quickcheck =
+{ spec-quickcheck =
   { dependencies = [ "aff", "prelude", "quickcheck", "random", "spec" ]
   , repo = "https://github.com/owickstrom/purescript-spec-quickcheck.git"
   , version = "v3.1.0"

--- a/src/groups/purescript-spec.dhall
+++ b/src/groups/purescript-spec.dhall
@@ -17,4 +17,9 @@
   , repo = "https://github.com/purescript-spec/purescript-spec.git"
   , version = "v4.0.1"
   }
+, spec-discovery =
+  { dependencies = [ "prelude", "effect", "arrays", "spec", "node-fs" ]
+  , repo = "https://github.com/purescript-spec/purescript-spec-discovery.git"
+  , version = "v5.0.0"
+  }
 }


### PR DESCRIPTION
Update `spec-discovery` to version `5.0.0`.
Note that running `make` also formatted the `collegevine.dhall` file for me so I split this in two commits.