### PR TITLE
Add EpicOrange/react-keybind

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3594,6 +3594,14 @@
     "repo": "https://github.com/robertdp/purescript-react-halo.git",
     "version": "v0.2.3"
   },
+  "react-keybind": {
+    "dependencies": [
+      "react-basic",
+      "react-basic-classic"
+    ],
+    "repo": "https://github.com/EpicOrange/purescript-react-keybind.git",
+    "version": "v0.8.1"
+  },
   "react-queue": {
     "dependencies": [
       "exceptions",

--- a/src/groups/epicorange.dhall
+++ b/src/groups/epicorange.dhall
@@ -1,0 +1,6 @@
+{ react-keybind =
+  { dependencies = [ "react-basic", "react-basic-classic" ]
+  , repo = "https://github.com/EpicOrange/purescript-react-keybind.git"
+  , version = "v0.8.1"
+  }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -24,6 +24,7 @@ let packages =
       ⫽ ./groups/danieljharvey.dhall
       ⫽ ./groups/dretch.dhall
       ⫽ ./groups/drewolson.dhall
+      ⫽ ./groups/epicorange.dhall
       ⫽ ./groups/epost.dhall
       ⫽ ./groups/ethul.dhall
       ⫽ ./groups/fehrenbach.dhall


### PR DESCRIPTION
Hey, this is my first package! And I have a question about this process.

Right now `react-keybind` has two dependencies, `react-basic` and `react-basic-classic`. The second one, `react-basic-classic`, is published in package-sets, but not published on [purescript/registry](https://github.com/purescript/registry) or Pursuit. So the only way `bower.json` can find it is via a direct link:

```
    "dependencies": {
        "purescript-react-basic": "^v15.0.0",
        "purescript-react-basic-classic": "git://github.com/lumihq/purescript-react-basic-classic.git#v1.0.1"
    }
```

This is what's currently published at `react-keybind`. I understand that directly linking to the dependency repo url might lead to some reproducibility snags if the dependency decides to move its url (pretty unlikely) so is this an okay configuration?

In other news, everything seems to verify okay:

```
[info] Verifying 1 packages, this might take a while..
[info] Verifying package "react-keybind"
[info] Build succeeded.
[info] Successfully verified "react-keybind"
```