### PR TITLE
Switch css repo back to purescript-contrib and use main branch

### DIFF
--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -140,8 +140,8 @@
     , "these"
     , "transformers"
     ]
-  , repo = "https://github.com/jordanmartinez/purescript-css.git"
-  , version = "accountForFunctorMigration"
+  , repo = "https://github.com/purescript-contrib/purescript-css.git"
+  , version = "main"
   }
 , fixed-points =
   { dependencies = [ "exists", "newtype", "prelude", "transformers" ]


### PR DESCRIPTION
Reverts the temporary fix needed to make CI build in #807 

Part of purescript/purescript-profunctor#23