### PR TITLE
Upgrade debug, elmish, and elmish-html

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -812,7 +812,7 @@
       "web-html"
     ],
     "repo": "https://github.com/collegevine/purescript-elmish.git",
-    "version": "v0.4.0"
+    "version": "v0.5.0"
   },
   "elmish-html": {
     "dependencies": [
@@ -820,7 +820,7 @@
       "foreign-object"
     ],
     "repo": "https://github.com/collegevine/purescript-elmish-html.git",
-    "version": "v0.2.0"
+    "version": "v0.3.0"
   },
   "email-validate": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -693,14 +693,6 @@
     "repo": "https://github.com/garyb/purescript-debug.git",
     "version": "v5.0.0"
   },
-  "debuggest": {
-    "dependencies": [
-      "prelude",
-      "unsafe-coerce"
-    ],
-    "repo": "https://github.com/ursi/purescript-debuggest.git",
-    "version": "v0.4.0"
-  },
   "decimals": {
     "dependencies": [
       "maybe"

--- a/packages.json
+++ b/packages.json
@@ -690,7 +690,7 @@
       "prelude"
     ],
     "repo": "https://github.com/garyb/purescript-debug.git",
-    "version": "v4.0.1"
+    "version": "v5.0.0"
   },
   "debuggest": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -813,7 +813,7 @@
       "web-html"
     ],
     "repo": "https://github.com/collegevine/purescript-elmish.git",
-    "version": "v0.5.0"
+    "version": "v0.5.1"
   },
   "elmish-html": {
     "dependencies": [
@@ -821,7 +821,7 @@
       "foreign-object"
     ],
     "repo": "https://github.com/collegevine/purescript-elmish-html.git",
-    "version": "v0.3.0"
+    "version": "v0.3.1"
   },
   "email-validate": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -687,6 +687,7 @@
   },
   "debug": {
     "dependencies": [
+      "functions",
       "prelude"
     ],
     "repo": "https://github.com/garyb/purescript-debug.git",

--- a/src/groups/collegevine.dhall
+++ b/src/groups/collegevine.dhall
@@ -15,11 +15,11 @@
     , "web-html"
     ]
   , repo = "https://github.com/collegevine/purescript-elmish.git"
-  , version = "v0.4.0"
+  , version = "v0.5.0"
   }
 , elmish-html =
   { dependencies = [ "elmish", "foreign-object" ]
   , repo = "https://github.com/collegevine/purescript-elmish-html.git"
-  , version = "v0.2.0"
+  , version = "v0.3.0"
   }
 }

--- a/src/groups/collegevine.dhall
+++ b/src/groups/collegevine.dhall
@@ -15,11 +15,11 @@
     , "web-html"
     ]
   , repo = "https://github.com/collegevine/purescript-elmish.git"
-  , version = "v0.5.0"
+  , version = "v0.5.1"
   }
 , elmish-html =
   { dependencies = [ "elmish", "foreign-object" ]
   , repo = "https://github.com/collegevine/purescript-elmish-html.git"
-  , version = "v0.3.0"
+  , version = "v0.3.1"
   }
 }

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -11,7 +11,7 @@
 , debug =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/garyb/purescript-debug.git"
-  , version = "v4.0.1"
+  , version = "v5.0.0"
   }
 , codec-argonaut =
   { dependencies =

--- a/src/groups/garyb.dhall
+++ b/src/groups/garyb.dhall
@@ -9,7 +9,7 @@
   , version = "v4.0.0"
   }
 , debug =
-  { dependencies = [ "prelude" ]
+  { dependencies = [ "prelude", "functions" ]
   , repo = "https://github.com/garyb/purescript-debug.git"
   , version = "v5.0.0"
   }

--- a/src/groups/ursi.dhall
+++ b/src/groups/ursi.dhall
@@ -34,13 +34,13 @@
   , repo = "https://github.com/ursi/purescript-task.git"
   , version = "v0.3.0"
   }
--}
-{ debuggest =
+, debuggest =
   { dependencies = [ "prelude", "unsafe-coerce" ]
   , repo = "https://github.com/ursi/purescript-debuggest.git"
   , version = "v0.4.0"
   }
-, point-free =
+-}
+{ point-free =
   { dependencies = [ "prelude" ]
   , repo = "https://github.com/ursi/purescript-point-free.git"
   , version = "v0.1.3"


### PR DESCRIPTION
The new v0.5.1 of `elmish` is compatible with the new v5.0.0 of `debug`

~There is a bit of a confusion about where `debug` should be in `devDependencies` in `bower.json` or not (see https://github.com/collegevine/purescript-elmish/pull/34#issuecomment-799673449), but this shouldn't affect package sets as far as I understand.~ Resolved now

**Edit**: ok, it looks like there is some other incompatibility in some other library

**Edit 2**: aha, found it. `debuggest` [has the same module name](https://github.com/ursi/purescript-debuggest/blob/master/src/Debug.purs#L1).

**Edit 3**: I commented out `debuggest` for now. Not sure if that's acceptable.