### PR TITLE
Update/uncomment foreign-generic and uuid

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -985,6 +985,19 @@
     "repo": "https://github.com/purescript/purescript-foreign.git",
     "version": "v6.0.0"
   },
+  "foreign-generic": {
+    "dependencies": [
+      "effect",
+      "exceptions",
+      "foreign",
+      "foreign-object",
+      "identity",
+      "ordered-collections",
+      "record"
+    ],
+    "repo": "https://github.com/paf31/purescript-foreign-generic.git",
+    "version": "v11.0.0"
+  },
   "foreign-object": {
     "dependencies": [
       "arrays",

--- a/packages.json
+++ b/packages.json
@@ -3448,6 +3448,17 @@
     "repo": "https://github.com/purescript-contrib/purescript-uri.git",
     "version": "v8.0.0"
   },
+  "uuid": {
+    "dependencies": [
+      "console",
+      "effect",
+      "foreign-generic",
+      "maybe",
+      "spec"
+    ],
+    "repo": "https://github.com/spicydonuts/purescript-uuid.git",
+    "version": "v7.0.0"
+  },
   "validation": {
     "dependencies": [
       "bifunctors",

--- a/src/groups/paf31.dhall
+++ b/src/groups/paf31.dhall
@@ -1,5 +1,4 @@
-{-
-, foreign-generic =
+{ foreign-generic =
   { dependencies =
     [ "effect"
     , "exceptions"
@@ -10,8 +9,9 @@
     , "record"
     ]
   , repo = "https://github.com/paf31/purescript-foreign-generic.git"
-  , version = "v10.0.0"
+  , version = "v11.0.0"
   }
+{-
 , memoize =
   { dependencies =
     [ "either"
@@ -65,7 +65,7 @@
   , version = "v5.1.0"
   }
 -}
-{ drawing =
+, drawing =
   { dependencies =
     [ "canvas", "colors", "integers", "lists", "math", "prelude" ]
   , repo = "https://github.com/paf31/purescript-drawing.git"

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -1,11 +1,9 @@
-{-
-, uuid =
+{ uuid =
   { dependencies = [ "effect", "maybe", "foreign-generic", "console", "spec" ]
   , repo = "https://github.com/spicydonuts/purescript-uuid.git"
   , version = "v7.0.0"
   }
--}
-{ react-basic-hooks =
+, react-basic-hooks =
   { dependencies =
     [ "prelude"
     , "aff-promise"


### PR DESCRIPTION
* https://github.com/paf31/purescript-foreign-generic/pull/61 has been merged and new version v11.0.0 cut
* `uuid` doesn't need any updates for PS 0.14, but it depends on `foreign-generic`