### PR TITLE
Pin nixpkgs to 20.09

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,8 @@
-{ pkgs ? import <nixpkgs> {} }:
-
 let
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
+  }) {};
+
   easy-ps = import (
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
@@ -11,6 +13,7 @@ let
   ) {
     inherit pkgs;
   };
+
   easy-dhall = import (
     pkgs.fetchFromGitHub {
       owner = "justinwoo";


### PR DESCRIPTION
The current `default.nix` uses the user's nixpkgs, which can cause `nix-shell --command make` to fail if their packages are older than necessary for the dependencies we have. For example, with a 19.03 nixpkgs:

```
λ nix-shell --run make
error: --- EvalError -------------------------------------------------------------------------------------------------------------- nix-shell
at: (22:25) in file: /nix/store/4qazpl999va119s45zcdwdjx8z9lcr4n-source/build.nix

    21| 
    22|   nativeBuildInputs = [ pkgs.installShellFiles ];
      |                         ^
    23| 

attribute 'installShellFiles' missing
(use '--show-trace' to show detailed location information)
```

This happens as late as the 19.09 prerelease versions of nixpkgs. Pinning nixpkgs ensures anyone running this code is able to at least successfully build and run the command.

The downside is that a user may have to download the 20.09 package set from cache if they don't have it.