### PR TITLE
Update `heckin` and `npm-package-json` to PureScript 0.14

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1775,6 +1775,24 @@
     "repo": "https://github.com/purescript-halogen/purescript-halogen-vdom.git",
     "version": "v7.0.1"
   },
+  "heckin": {
+    "dependencies": [
+      "aff",
+      "arrays",
+      "effect",
+      "foldable-traversable",
+      "maybe",
+      "prelude",
+      "psci-support",
+      "spec",
+      "strings",
+      "transformers",
+      "tuples",
+      "unicode"
+    ],
+    "repo": "https://github.com/maxdeviant/purescript-heckin.git",
+    "version": "v2.0.0"
+  },
   "heterogeneous": {
     "dependencies": [
       "either",
@@ -2548,6 +2566,20 @@
     ],
     "repo": "https://github.com/purescript-contrib/purescript-now.git",
     "version": "v5.0.0"
+  },
+  "npm-package-json": {
+    "dependencies": [
+      "argonaut",
+      "control",
+      "either",
+      "foreign-object",
+      "maybe",
+      "ordered-collections",
+      "prelude",
+      "psci-support"
+    ],
+    "repo": "https://github.com/maxdeviant/purescript-npm-package-json.git",
+    "version": "v2.0.0"
   },
   "nullable": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -1777,14 +1777,10 @@
   },
   "heckin": {
     "dependencies": [
-      "aff",
       "arrays",
-      "effect",
       "foldable-traversable",
       "maybe",
       "prelude",
-      "psci-support",
-      "spec",
       "strings",
       "transformers",
       "tuples",
@@ -2575,8 +2571,7 @@
       "foreign-object",
       "maybe",
       "ordered-collections",
-      "prelude",
-      "psci-support"
+      "prelude"
     ],
     "repo": "https://github.com/maxdeviant/purescript-npm-package-json.git",
     "version": "v2.0.0"

--- a/src/groups/maxdeviant.dhall
+++ b/src/groups/maxdeviant.dhall
@@ -1,23 +1,36 @@
-{-
-, heckin =
+{ heckin =
   { dependencies =
-    [ "arrays"
-    , "console"
+    [ "aff"
+    , "arrays"
     , "effect"
     , "foldable-traversable"
+    , "maybe"
+    , "prelude"
     , "psci-support"
+    , "spec"
+    , "strings"
+    , "transformers"
+    , "tuples"
     , "unicode"
     ]
   , repo = "https://github.com/maxdeviant/purescript-heckin.git"
-  , version = "v1.1.0"
+  , version = "v2.0.0"
   }
 , npm-package-json =
-  { dependencies = [ "argonaut", "console", "effect", "psci-support" ]
+  { dependencies =
+    [ "argonaut"
+    , "control"
+    , "either"
+    , "foreign-object"
+    , "maybe"
+    , "ordered-collections"
+    , "prelude"
+    , "psci-support"
+    ]
   , repo = "https://github.com/maxdeviant/purescript-npm-package-json.git"
-  , version = "v1.2.0"
+  , version = "v2.0.0"
   }
--}
-{ which =
+, which =
   { dependencies = [ "arrays", "console", "effect", "nullable", "psci-support" ]
   , repo = "https://github.com/maxdeviant/purescript-which.git"
   , version = "v0.1.0"

--- a/src/groups/maxdeviant.dhall
+++ b/src/groups/maxdeviant.dhall
@@ -1,13 +1,9 @@
 { heckin =
   { dependencies =
-    [ "aff"
-    , "arrays"
-    , "effect"
+    [ "arrays"
     , "foldable-traversable"
     , "maybe"
     , "prelude"
-    , "psci-support"
-    , "spec"
     , "strings"
     , "transformers"
     , "tuples"
@@ -25,7 +21,6 @@
     , "maybe"
     , "ordered-collections"
     , "prelude"
-    , "psci-support"
     ]
   , repo = "https://github.com/maxdeviant/purescript-npm-package-json.git"
   , version = "v2.0.0"


### PR DESCRIPTION
This PR updates the following packages to work with PureScript 0.14 and the latest package set:

- `heckin`
- `npm-package-json`