### PR TITLE
Add `ulid`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4430,6 +4430,17 @@
     "repo": "https://github.com/purescript-contrib/purescript-uint.git",
     "version": "v6.0.3"
   },
+  "ulid": {
+    "dependencies": [
+      "effect",
+      "functions",
+      "maybe",
+      "nullable",
+      "prelude"
+    ],
+    "repo": "https://github.com/maxdeviant/purescript-ulid.git",
+    "version": "v1.0.0"
+  },
   "undefinable": {
     "dependencies": [
       "functions",

--- a/packages.json
+++ b/packages.json
@@ -4439,7 +4439,7 @@
       "prelude"
     ],
     "repo": "https://github.com/maxdeviant/purescript-ulid.git",
-    "version": "v1.0.0"
+    "version": "v2.0.0"
   },
   "undefinable": {
     "dependencies": [

--- a/src/groups/maxdeviant.dhall
+++ b/src/groups/maxdeviant.dhall
@@ -25,6 +25,11 @@
   , repo = "https://github.com/maxdeviant/purescript-npm-package-json.git"
   , version = "v2.0.0"
   }
+, ulid =
+  { dependencies = [ "effect", "functions", "maybe", "nullable", "prelude" ]
+  , repo = "https://github.com/maxdeviant/purescript-ulid.git"
+  , version = "v1.0.0"
+  }
 , which =
   { dependencies = [ "arrays", "console", "effect", "nullable", "psci-support" ]
   , repo = "https://github.com/maxdeviant/purescript-which.git"

--- a/src/groups/maxdeviant.dhall
+++ b/src/groups/maxdeviant.dhall
@@ -28,7 +28,7 @@
 , ulid =
   { dependencies = [ "effect", "functions", "maybe", "nullable", "prelude" ]
   , repo = "https://github.com/maxdeviant/purescript-ulid.git"
-  , version = "v1.0.0"
+  , version = "v2.0.0"
   }
 , which =
   { dependencies = [ "arrays", "console", "effect", "nullable", "psci-support" ]


### PR DESCRIPTION
This PR adds the [`ulid`](https://pursuit.purescript.org/packages/purescript-ulid/2.0.0) package to the package set.

This package is a wrapper around the [npm package](https://www.npmjs.com/package/ulid) with the same name.