### PR TITLE
Upgrade to purs 0.14.4 and improve release script

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,8 +7,8 @@ let
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
       repo = "easy-purescript-nix";
-      rev = "bbef4245cd6810ea84e97a47c801947bfec9fadc";
-      sha256 = "00764zbwhbn61jwb5px2syzi2f9djyl8fmbd2p8wma985af54iwx";
+      rev = "0679c8e8f7432bdcedb6de84266fdc651d59c401";
+      sha256 = "13mbcgcfic6mxi84pkybbs427bbgyynnh4lvypv0x9c9nzkmna6m";
     }
   ) {
     inherit pkgs;

--- a/release.sh
+++ b/release.sh
@@ -1,15 +1,41 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash
+#!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 # Please use this script to cut new releases. It will generate a new tag name
 # based on the current date, update the latest releases file, and push the tag
 
-# TODO: fail if there's a tag with this same name, as sometimes we publish more than one per day
+# Fail if we are not on trunk
+BRANCH=$(git branch --show-current)
+if [ "${BRANCH}" != "master" ]; then
+  echo "Please checkout master branch";
+  exit 1;
+fi
+git pull
 
-LATEST_PURS="0.14.3"
+LATEST_PURS="0.14.4"
+
+NEW_STABLE_TAG="psc-${LATEST_PURS}"
+
+# Create the first tag for the compiler if it doesn't exist
+if git rev-parse "${NEW_STABLE_TAG}" >/dev/null 2>&1; then
+  echo "Stable tag '${NEW_STABLE_TAG}' already exists, skipping";
+else
+  echo "Creating and pushing new tag '${NEW_STABLE_TAG}'.."
+  git tag "${NEW_STABLE_TAG}";
+  git push origin "${NEW_STABLE_TAG}";
+fi
+
 NEW_TAG="psc-${LATEST_PURS}-`date +'%Y%m%d'`"
+
+# Fail if the new tag already exists
+# Note: exit status of the command is the conditional
+if git rev-parse "${NEW_TAG}" >/dev/null 2>&1; then
+  echo "Tag '${NEW_TAG}' already exists!";
+  exit 1;
+fi
+
+echo "Creating and pushing new tag '${NEW_TAG}'.."
 
 ./update-latest-compatible-sets.sh "${NEW_TAG}"
 
@@ -22,3 +48,5 @@ git push
 git tag "${NEW_TAG}"
 
 git push origin "${NEW_TAG}"
+
+echo "Done."


### PR DESCRIPTION
In this PR we:
- upgrade to `purs@0.14.4` in CI and in the release script
- add a check to the release script so that it fails if not run from trunk
- add the "stable releases" (for `psc-package` compatibility) to the release script