### PR TITLE
Add canvas-action and grid-reactors to the package set

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -558,6 +558,35 @@
     "repo": "https://github.com/purescript-web/purescript-canvas.git",
     "version": "v5.0.0"
   },
+  "canvas-action": {
+    "dependencies": [
+      "aff",
+      "arrays",
+      "canvas",
+      "colors",
+      "effect",
+      "either",
+      "exceptions",
+      "foldable-traversable",
+      "math",
+      "maybe",
+      "numbers",
+      "polymorphic-vectors",
+      "prelude",
+      "refs",
+      "run",
+      "transformers",
+      "tuples",
+      "type-equality",
+      "typelevel-prelude",
+      "unsafe-coerce",
+      "web-dom",
+      "web-events",
+      "web-html"
+    ],
+    "repo": "https://github.com/artemisSystem/purescript-canvas-action.git",
+    "version": "v7.0.0"
+  },
   "cartesian": {
     "dependencies": [
       "console",
@@ -1648,6 +1677,38 @@
     ],
     "repo": "https://github.com/purescript/purescript-graphs.git",
     "version": "v5.0.0"
+  },
+  "grid-reactors": {
+    "dependencies": [
+      "aff",
+      "arrays",
+      "canvas-action",
+      "colors",
+      "console",
+      "effect",
+      "exceptions",
+      "foldable-traversable",
+      "free",
+      "halogen",
+      "halogen-hooks",
+      "halogen-subscriptions",
+      "heterogeneous",
+      "integers",
+      "maybe",
+      "partial",
+      "prelude",
+      "psci-support",
+      "random",
+      "st",
+      "tailrec",
+      "transformers",
+      "tuples",
+      "web-events",
+      "web-html",
+      "web-uievents"
+    ],
+    "repo": "https://github.com/Eugleo/purescript-grid-reactors.git",
+    "version": "v0.0.1"
   },
   "group": {
     "dependencies": [

--- a/src/groups/anttih.dhall
+++ b/src/groups/anttih.dhall
@@ -16,4 +16,33 @@
   , repo = "https://github.com/anttih/purescript-rationals.git"
   , version = "v5.0.0"
   }
+, canvas-action =
+  { dependencies =
+    [ "aff"
+    , "arrays"
+    , "canvas"
+    , "colors"
+    , "effect"
+    , "either"
+    , "exceptions"
+    , "foldable-traversable"
+    , "math"
+    , "maybe"
+    , "numbers"
+    , "polymorphic-vectors"
+    , "prelude"
+    , "refs"
+    , "run"
+    , "transformers"
+    , "tuples"
+    , "type-equality"
+    , "typelevel-prelude"
+    , "unsafe-coerce"
+    , "web-dom"
+    , "web-events"
+    , "web-html"
+    ]
+  , repo = "https://github.com/artemisSystem/purescript-canvas-action.git"
+  , version = "v7.0.0"
+  }
 }

--- a/src/groups/eugleo.dhall
+++ b/src/groups/eugleo.dhall
@@ -1,0 +1,33 @@
+{ grid-reactors =
+  { version = "v0.0.1"
+  , repo = "https://github.com/Eugleo/purescript-grid-reactors.git"
+  , dependencies =
+    [ "aff"
+    , "arrays"
+    , "canvas-action"
+    , "colors"
+    , "console"
+    , "effect"
+    , "exceptions"
+    , "foldable-traversable"
+    , "free"
+    , "halogen"
+    , "halogen-hooks"
+    , "halogen-subscriptions"
+    , "heterogeneous"
+    , "integers"
+    , "maybe"
+    , "partial"
+    , "prelude"
+    , "psci-support"
+    , "random"
+    , "st"
+    , "tailrec"
+    , "transformers"
+    , "tuples"
+    , "web-events"
+    , "web-html"
+    , "web-uievents"
+    ]
+  }
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -131,5 +131,6 @@ let packages =
       ⫽ ./groups/mateiadrielrafael.dhall
       ⫽ ./groups/deadshot465.dhall
       ⫽ ./groups/lfarroco.dhall
+      ⫽ ./groups/eugleo.dhall
 
 in  packages


### PR DESCRIPTION
As per [this thread over at canvas-action repo](https://github.com/artemisSystem/purescript-canvas-action/issues/3), I've added not only my `grid-reactors`, but also `canvas-action` to the package set.