### PR TITLE
Update `grid-reactors` to v2.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1760,7 +1760,7 @@
       "web-uievents"
     ],
     "repo": "https://github.com/Eugleo/purescript-grid-reactors.git",
-    "version": "v0.0.1"
+    "version": "v2.1.0"
   },
   "group": {
     "dependencies": [

--- a/src/groups/eugleo.dhall
+++ b/src/groups/eugleo.dhall
@@ -1,5 +1,5 @@
 { grid-reactors =
-  { version = "v0.0.1"
+  { version = "v2.1.0"
   , repo = "https://github.com/Eugleo/purescript-grid-reactors.git"
   , dependencies =
     [ "aff"


### PR DESCRIPTION
This PR updates `grid-reactors` to v2.1.0.

https://github.com/Eugleo/purescript-grid-reactors/compare/v0.0.1...v2.1.0