### PR TITLE
Update `halogen-store` to v0.2.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1860,7 +1860,7 @@
       "unsafe-reference"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-store.git",
-    "version": "v0.2.0"
+    "version": "v0.2.1"
   },
   "halogen-storybook": {
     "dependencies": [

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -25,7 +25,7 @@
     , "unsafe-reference"
     ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-store.git"
-  , version = "v0.2.0"
+  , version = "v0.2.1"
   }
 , slug =
   { dependencies =


### PR DESCRIPTION
This PR updates `halogen-store` to v0.2.1.

https://github.com/thomashoneyman/purescript-halogen-store/compare/v0.2.0...v0.2.1