### PR TITLE
Update `phaser` to v0.4.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3112,12 +3112,12 @@
     "dependencies": [
       "aff",
       "effect",
-      "nullable",
+      "option",
       "prelude",
       "psci-support"
     ],
     "repo": "https://github.com/lfarroco/purescript-phaser.git",
-    "version": "v0.2.0"
+    "version": "v0.4.0"
   },
   "phoenix": {
     "dependencies": [

--- a/src/groups/lfarroco.dhall
+++ b/src/groups/lfarroco.dhall
@@ -1,6 +1,6 @@
 { phaser =
-  { dependencies = [ "aff", "effect", "prelude", "nullable", "psci-support" ]
+  { dependencies = [ "aff", "effect", "option", "prelude", "psci-support" ]
   , repo = "https://github.com/lfarroco/purescript-phaser.git"
-  , version = "v0.2.0"
+  , version = "v0.4.0"
   }
 }


### PR DESCRIPTION
This PR updates `phaser` to v0.4.0.

https://github.com/lfarroco/purescript-phaser/compare/v0.2.0...v0.4.0

Closes #1011.