### PR TITLE
Update `ordered-collections` to v2.0.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2897,7 +2897,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/purescript/purescript-ordered-collections.git",
-    "version": "v2.0.1"
+    "version": "v2.0.2"
   },
   "ordered-set": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -355,7 +355,7 @@
     , "unfoldable"
     ]
   , repo = "https://github.com/purescript/purescript-ordered-collections.git"
-  , version = "v2.0.1"
+  , version = "v2.0.2"
   }
 , orders =
   { dependencies = [ "newtype", "prelude" ]


### PR DESCRIPTION
This PR updates `ordered-collections` to v2.0.2.

https://github.com/purescript/purescript-ordered-collections/compare/v2.0.1...v2.0.2