### PR TITLE
Update `nonempty` to v6.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2686,7 +2686,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/purescript/purescript-nonempty.git",
-    "version": "v6.0.0"
+    "version": "v6.1.0"
   },
   "now": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -333,7 +333,7 @@
     , "unfoldable"
     ]
   , repo = "https://github.com/purescript/purescript-nonempty.git"
-  , version = "v6.0.0"
+  , version = "v6.1.0"
   }
 , numbers =
   { dependencies = [ "functions", "math", "maybe" ]


### PR DESCRIPTION
This PR updates `nonempty` to v6.1.0.

https://github.com/purescript/purescript-nonempty/compare/v6.0.0...v6.1.0