### PR TITLE
Update `halogen-formless` to v2.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1820,7 +1820,7 @@
       "variant"
     ],
     "repo": "https://github.com/thomashoneyman/purescript-halogen-formless.git",
-    "version": "v2.0.1"
+    "version": "v2.1.0"
   },
   "halogen-hooks": {
     "dependencies": [

--- a/src/groups/thomashoneyman.dhall
+++ b/src/groups/thomashoneyman.dhall
@@ -2,7 +2,7 @@
   { dependencies =
     [ "halogen", "variant", "heterogeneous", "profunctor-lenses" ]
   , repo = "https://github.com/thomashoneyman/purescript-halogen-formless.git"
-  , version = "v2.0.1"
+  , version = "v2.1.0"
   }
 , halogen-hooks =
   { dependencies = [ "halogen" ]


### PR DESCRIPTION
This PR updates `halogen-formless` to v2.1.0.

https://github.com/thomashoneyman/purescript-halogen-formless/compare/v2.0.1...v2.1.0