### PR TITLE
Update `aff-bus` to v5.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -35,9 +35,20 @@
   },
   "aff-bus": {
     "dependencies": [
+      "aff",
       "avar",
+      "console",
       "effect",
-      "prelude"
+      "either",
+      "exceptions",
+      "foldable-traversable",
+      "lists",
+      "prelude",
+      "psci-support",
+      "refs",
+      "tailrec",
+      "transformers",
+      "tuples"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-aff-bus.git",
     "version": "v5.0.1"

--- a/packages.json
+++ b/packages.json
@@ -44,7 +44,6 @@
       "foldable-traversable",
       "lists",
       "prelude",
-      "psci-support",
       "refs",
       "tailrec",
       "transformers",

--- a/packages.json
+++ b/packages.json
@@ -40,7 +40,7 @@
       "prelude"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-aff-bus.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "aff-coroutines": {
     "dependencies": [

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -27,7 +27,7 @@
 , aff-bus =
   { dependencies = [ "avar", "effect", "prelude" ]
   , repo = "https://github.com/purescript-contrib/purescript-aff-bus.git"
-  , version = "v5.0.0"
+  , version = "v5.0.1"
   }
 , aff-coroutines =
   { dependencies = [ "aff", "avar", "coroutines", "effect" ]

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -35,7 +35,6 @@
     , "foldable-traversable"
     , "lists"
     , "prelude"
-    , "psci-support"
     , "refs"
     , "tailrec"
     , "transformers"

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -25,7 +25,22 @@
   , version = "v6.0.0"
   }
 , aff-bus =
-  { dependencies = [ "avar", "effect", "prelude" ]
+  { dependencies =
+    [ "aff"
+    , "avar"
+    , "console"
+    , "effect"
+    , "either"
+    , "exceptions"
+    , "foldable-traversable"
+    , "lists"
+    , "prelude"
+    , "psci-support"
+    , "refs"
+    , "tailrec"
+    , "transformers"
+    , "tuples"
+    ]
   , repo = "https://github.com/purescript-contrib/purescript-aff-bus.git"
   , version = "v5.0.1"
   }


### PR DESCRIPTION
This PR updates `aff-bus` to v5.0.1.

https://github.com/purescript-contrib/purescript-aff-bus/compare/v5.0.0...v5.0.1