### PR TITLE
Update `parsing` to v7.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3004,7 +3004,7 @@
       "unicode"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-parsing.git",
-    "version": "v7.0.0"
+    "version": "v7.0.1"
   },
   "parsing-dataview": {
     "dependencies": [

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -327,7 +327,7 @@
     , "unicode"
     ]
   , repo = "https://github.com/purescript-contrib/purescript-parsing.git"
-  , version = "v7.0.0"
+  , version = "v7.0.1"
   }
 , pathy =
   { dependencies =


### PR DESCRIPTION
This PR updates `parsing` to v7.0.1.

https://github.com/purescript-contrib/purescript-parsing/compare/v7.0.0...v7.0.1