### PR TITLE
Update `unicode` to v5.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4711,7 +4711,7 @@
       "strings"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-unicode.git",
-    "version": "v5.0.0"
+    "version": "v5.0.1"
   },
   "unordered-collections": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -4706,21 +4706,9 @@
   },
   "unicode": {
     "dependencies": [
-      "arrays",
-      "assert",
-      "console",
-      "effect",
-      "enums",
       "foldable-traversable",
-      "integers",
       "maybe",
-      "partial",
-      "prelude",
-      "quickcheck",
-      "random",
-      "strings",
-      "transformers",
-      "unsafe-coerce"
+      "strings"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-unicode.git",
     "version": "v5.0.1"

--- a/packages.json
+++ b/packages.json
@@ -4706,9 +4706,21 @@
   },
   "unicode": {
     "dependencies": [
+      "arrays",
+      "assert",
+      "console",
+      "effect",
+      "enums",
       "foldable-traversable",
+      "integers",
       "maybe",
-      "strings"
+      "partial",
+      "prelude",
+      "quickcheck",
+      "random",
+      "strings",
+      "transformers",
+      "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript-contrib/purescript-unicode.git",
     "version": "v5.0.1"

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -474,23 +474,7 @@
   , version = "v6.0.3"
   }
 , unicode =
-  { dependencies =
-    [ "arrays"
-    , "assert"
-    , "console"
-    , "effect"
-    , "enums"
-    , "foldable-traversable"
-    , "integers"
-    , "maybe"
-    , "partial"
-    , "prelude"
-    , "quickcheck"
-    , "random"
-    , "strings"
-    , "transformers"
-    , "unsafe-coerce"
-    ]
+  { dependencies = [ "foldable-traversable", "maybe", "strings" ]
   , repo = "https://github.com/purescript-contrib/purescript-unicode.git"
   , version = "v5.0.1"
   }

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -474,7 +474,23 @@
   , version = "v6.0.3"
   }
 , unicode =
-  { dependencies = [ "foldable-traversable", "maybe", "strings" ]
+  { dependencies =
+    [ "arrays"
+    , "assert"
+    , "console"
+    , "effect"
+    , "enums"
+    , "foldable-traversable"
+    , "integers"
+    , "maybe"
+    , "partial"
+    , "prelude"
+    , "quickcheck"
+    , "random"
+    , "strings"
+    , "transformers"
+    , "unsafe-coerce"
+    ]
   , repo = "https://github.com/purescript-contrib/purescript-unicode.git"
   , version = "v5.0.1"
   }

--- a/src/groups/purescript-contrib.dhall
+++ b/src/groups/purescript-contrib.dhall
@@ -476,7 +476,7 @@
 , unicode =
   { dependencies = [ "foldable-traversable", "maybe", "strings" ]
   , repo = "https://github.com/purescript-contrib/purescript-unicode.git"
-  , version = "v5.0.0"
+  , version = "v5.0.1"
   }
 , unsafe-reference =
   { dependencies = [ "prelude" ]


### PR DESCRIPTION
This PR updates `unicode` to v5.0.1.

https://github.com/purescript-contrib/purescript-unicode/compare/v5.0.0...v5.0.1