### PR TITLE
Update `free` to v6.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1505,7 +1505,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-free.git",
-    "version": "v6.1.0"
+    "version": "v6.2.0"
   },
   "freeap": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -203,7 +203,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript/purescript-free.git"
-  , version = "v6.1.0"
+  , version = "v6.2.0"
   }
 , functions =
   { dependencies = [ "prelude" ]


### PR DESCRIPTION
This PR updates `free` to v6.2.0.

https://github.com/purescript/purescript-free/compare/v6.1.0...v6.2.0