### PR TITLE
Bump purescript-supply version

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4388,14 +4388,15 @@
   "supply": {
     "dependencies": [
       "console",
+      "control",
       "effect",
       "lazy",
-      "newtype",
+      "prelude",
       "refs",
       "tuples"
     ],
     "repo": "https://github.com/ajnsit/purescript-supply.git",
-    "version": "v0.1.0"
+    "version": "v0.2.0"
   },
   "systemd-journald": {
     "dependencies": [

--- a/src/groups/ajnsit.dhall
+++ b/src/groups/ajnsit.dhall
@@ -1,6 +1,7 @@
 { supply =
-  { dependencies = [ "console", "effect", "newtype", "tuples", "lazy", "refs" ]
+  { dependencies =
+    [ "console", "control", "effect", "lazy", "prelude", "refs", "tuples" ]
   , repo = "https://github.com/ajnsit/purescript-supply.git"
-  , version = "v0.1.0"
+  , version = "v0.2.0"
   }
 }


### PR DESCRIPTION
Released a new version of purescript-supply with an updated license identifier as needed for the new registry.

Ref: https://github.com/ajnsit/purescript-supply/pull/2