### PR TITLE
Update `gl-matrix` to v2.1.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1626,7 +1626,7 @@
       "psci-support"
     ],
     "repo": "https://github.com/dirkz/purescript-gl-matrix.git",
-    "version": "v2.0.1"
+    "version": "v2.1.0"
   },
   "gomtang-basic": {
     "dependencies": [

--- a/src/groups/dirkz.dhall
+++ b/src/groups/dirkz.dhall
@@ -10,6 +10,6 @@
     , "psci-support"
     ]
   , repo = "https://github.com/dirkz/purescript-gl-matrix.git"
-  , version = "v2.0.1"
+  , version = "v2.1.0"
   }
 }


### PR DESCRIPTION
This PR updates `gl-matrix` to v2.1.0.

https://github.com/dirkz/purescript-gl-matrix/compare/v2.0.1...v2.1.0