### PR TITLE
Update `react-basic-hooks` to v7.0.1

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3692,23 +3692,34 @@
     "dependencies": [
       "aff",
       "aff-promise",
+      "bifunctors",
       "console",
+      "control",
       "datetime",
       "effect",
       "either",
+      "exceptions",
+      "foldable-traversable",
+      "functions",
       "indexed-monad",
+      "integers",
       "maybe",
       "newtype",
+      "now",
+      "nullable",
+      "ordered-collections",
       "prelude",
       "psci-support",
       "react-basic",
+      "refs",
+      "tuples",
       "type-equality",
       "unsafe-coerce",
       "unsafe-reference",
       "web-html"
     ],
     "repo": "https://github.com/spicydonuts/purescript-react-basic-hooks.git",
-    "version": "v7.0.0"
+    "version": "v7.0.1"
   },
   "react-dom": {
     "dependencies": [

--- a/src/groups/spicydonuts.dhall
+++ b/src/groups/spicydonuts.dhall
@@ -5,24 +5,35 @@
   }
 , react-basic-hooks =
   { dependencies =
-    [ "prelude"
+    [ "aff"
     , "aff-promise"
-    , "aff"
+    , "bifunctors"
     , "console"
+    , "control"
     , "datetime"
     , "effect"
     , "either"
+    , "exceptions"
+    , "foldable-traversable"
+    , "functions"
     , "indexed-monad"
+    , "integers"
     , "maybe"
     , "newtype"
+    , "now"
+    , "nullable"
+    , "ordered-collections"
+    , "prelude"
     , "psci-support"
     , "react-basic"
+    , "refs"
+    , "tuples"
     , "type-equality"
     , "unsafe-coerce"
     , "unsafe-reference"
     , "web-html"
     ]
   , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v7.0.0"
+  , version = "v7.0.1"
   }
 }


### PR DESCRIPTION
This PR updates `react-basic-hooks` to v7.0.1.

https://github.com/megamaddu/purescript-react-basic-hooks/compare/v7.0.0...v7.0.1