### PR TITLE
Update `node-fs` to v6.2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2636,7 +2636,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript-node/purescript-node-fs.git",
-    "version": "v6.1.0"
+    "version": "v6.2.0"
   },
   "node-fs-aff": {
     "dependencies": [

--- a/src/groups/purescript-node.dhall
+++ b/src/groups/purescript-node.dhall
@@ -41,7 +41,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript-node/purescript-node-fs.git"
-  , version = "v6.1.0"
+  , version = "v6.2.0"
   }
 , node-fs-aff =
   { dependencies = [ "aff", "either", "node-fs", "node-path" ]


### PR DESCRIPTION
This PR updates `node-fs` to v6.2.0.

https://github.com/purescript-node/purescript-node-fs/compare/v6.1.0...v6.2.0