### PR TITLE
Update `expect-inferred` to v3.0.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1283,7 +1283,7 @@
       "typelevel-prelude"
     ],
     "repo": "https://github.com/justinwoo/purescript-expect-inferred.git",
-    "version": "v2.0.0"
+    "version": "v3.0.0"
   },
   "express": {
     "dependencies": [

--- a/src/groups/justinwoo.dhall
+++ b/src/groups/justinwoo.dhall
@@ -95,7 +95,7 @@
 { expect-inferred =
   { dependencies = [ "prelude", "typelevel-prelude" ]
   , repo = "https://github.com/justinwoo/purescript-expect-inferred.git"
-  , version = "v2.0.0"
+  , version = "v3.0.0"
   }
 , gomtang-basic =
   { dependencies = [ "console", "effect", "prelude", "record", "web-html" ]


### PR DESCRIPTION
This PR updates `expect-inferred` to v3.0.0.

https://github.com/justinwoo/purescript-expect-inferred/compare/v2.0.0...v3.0.0