### PR TITLE
Use original repo for easy-purescript-nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ let
 
   easy-ps = import (
     pkgs.fetchFromGitHub {
-      owner = "jordanmartinez";
+      owner = "justinwoo";
       repo = "easy-purescript-nix";
       rev = "b0ac14ff90ca7bd6eb7a2d125d94b4f9212e7595";
       sha256 = "1zxbxrnznr59a3z6mh2a2pp0afgkv2rvqp17gnyn0wqs21q99xz1";

--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,7 @@ let
     inherit pkgs;
   };
 
-  purs = easy-ps.purs-0_15_0_alpha_02;
+  purs = easy-ps.purs-0_15_0;
 
 in
 pkgs.runCommand "easy-ps-test" {


### PR DESCRIPTION
This reverts the temporary change I made in #1075. Blocked by https://github.com/justinwoo/easy-purescript-nix/pull/195

Once the blocker is resolved, I can update the `rev` and `sha256` fields.