### PR TITLE
spicydonuts -> megamaddu; add react-basic-hooks

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2908,6 +2908,38 @@
     "repo": "https://github.com/lumihq/purescript-react-basic-dom.git",
     "version": "v5.0.0"
   },
+  "react-basic-hooks": {
+    "dependencies": [
+      "aff",
+      "aff-promise",
+      "bifunctors",
+      "console",
+      "control",
+      "datetime",
+      "effect",
+      "either",
+      "exceptions",
+      "foldable-traversable",
+      "functions",
+      "indexed-monad",
+      "integers",
+      "maybe",
+      "newtype",
+      "now",
+      "nullable",
+      "ordered-collections",
+      "prelude",
+      "react-basic",
+      "refs",
+      "tuples",
+      "type-equality",
+      "unsafe-coerce",
+      "unsafe-reference",
+      "web-html"
+    ],
+    "repo": "https://github.com/megamaddu/purescript-react-basic-hooks.git",
+    "version": "v8.0.0"
+  },
   "react-dom": {
     "dependencies": [
       "effect",

--- a/src/groups/megamaddu.dhall
+++ b/src/groups/megamaddu.dhall
@@ -3,7 +3,8 @@
   , repo = "https://github.com/spicydonuts/purescript-uuid.git"
   , version = "v8.0.0"
   }
-, react-basic-hooks =
+-}
+{ react-basic-hooks =
   { dependencies =
     [ "aff"
     , "aff-promise"
@@ -24,7 +25,6 @@
     , "nullable"
     , "ordered-collections"
     , "prelude"
-    , "psci-support"
     , "react-basic"
     , "refs"
     , "tuples"
@@ -33,8 +33,7 @@
     , "unsafe-reference"
     , "web-html"
     ]
-  , repo = "https://github.com/spicydonuts/purescript-react-basic-hooks.git"
-  , version = "v7.0.1"
+  , repo = "https://github.com/megamaddu/purescript-react-basic-hooks.git"
+  , version = "v8.0.0"
   }
--}
-{=}
+}

--- a/src/packages.dhall
+++ b/src/packages.dhall
@@ -77,6 +77,7 @@ let packages =
       ⫽ ./groups/matthew-hilty.dhall
       ⫽ ./groups/maxdeviant.dhall
       ⫽ ./groups/meeshkan.dhall
+      ⫽ ./groups/megamaddu.dhall
       ⫽ ./groups/menelaos.dhall
       ⫽ ./groups/michaelxavier.dhall
       ⫽ ./groups/mjepronk.dhall
@@ -119,7 +120,6 @@ let packages =
       ⫽ ./groups/sigilion.dhall
       ⫽ ./groups/slamdata.dhall
       ⫽ ./groups/sodiumfrp.dhall
-      ⫽ ./groups/spicydonuts.dhall
       ⫽ ./groups/srghma.dhall
       ⫽ ./groups/thimoteus.dhall
       ⫽ ./groups/thomashoneyman.dhall


### PR DESCRIPTION
This also drops the psci-support package in react-basic-hooks

This unblocks https://github.com/purescript-contrib/purescript-book/pull/419#issuecomment-1156004304