### PR TITLE
Fix `Char` `Enum` instance (Update enums & strings to v6.0.1)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1001,7 +1001,7 @@
       "unfoldable"
     ],
     "repo": "https://github.com/purescript/purescript-enums.git",
-    "version": "v6.0.0"
+    "version": "v6.0.1"
   },
   "exceptions": {
     "dependencies": [

--- a/packages.json
+++ b/packages.json
@@ -3876,7 +3876,7 @@
       "unsafe-coerce"
     ],
     "repo": "https://github.com/purescript/purescript-strings.git",
-    "version": "v6.0.0"
+    "version": "v6.0.1"
   },
   "strings-extra": {
     "dependencies": [

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -483,7 +483,7 @@
     , "unsafe-coerce"
     ]
   , repo = "https://github.com/purescript/purescript-strings.git"
-  , version = "v6.0.0"
+  , version = "v6.0.1"
   }
 , tailrec =
   { dependencies =

--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -111,7 +111,7 @@
     , "unfoldable"
     ]
   , repo = "https://github.com/purescript/purescript-enums.git"
-  , version = "v6.0.0"
+  , version = "v6.0.1"
   }
 , exceptions =
   { dependencies = [ "effect", "either", "maybe", "prelude" ]


### PR DESCRIPTION
Updates `enums` so that it includes the correct implementation for `Char`'s `Enum` instance. See https://github.com/purescript/purescript-strings/issues/153